### PR TITLE
feat(community): 마이페이지 api 연결

### DIFF
--- a/apps/community/src/apis/my/remotes.ts
+++ b/apps/community/src/apis/my/remotes.ts
@@ -12,6 +12,11 @@ interface MyProfile {
 
 type MyProfileUpdate = Pick<MyProfile, 'phone' | 'email'>;
 
+interface MyPassword {
+  originalPassword: string;
+  newPassword: string;
+}
+
 function getMyProfile() {
   return http.get<MyProfile>(END_POINT.MY_PROFILE);
 }
@@ -20,4 +25,18 @@ function patchMyProfile(data: MyProfileUpdate) {
   return http.patch<MyProfileUpdate>(END_POINT.EDIT_MY_PROFILE, data);
 }
 
-export { type MyProfile, type MyProfileUpdate, getMyProfile, patchMyProfile };
+function patchChangePassword(data: {
+  originalPassword: string;
+  newPassword: string;
+}) {
+  return http.patch(END_POINT.CHANGE_PASSWORD, data);
+}
+
+export {
+  type MyProfile,
+  type MyProfileUpdate,
+  type MyPassword,
+  getMyProfile,
+  patchMyProfile,
+  patchChangePassword,
+};

--- a/apps/community/src/components/my/change-password/change-password-form.tsx
+++ b/apps/community/src/components/my/change-password/change-password-form.tsx
@@ -6,12 +6,17 @@ import { z } from 'zod';
 
 import { Button, Input } from '@aics-client/design-system';
 import * as styles from '~/components/my/change-password/change-password-form.css';
+import { useChangePasswordMutation } from '~/hooks/use-change-password-mutation';
 
 const changePasswordSchema = z
   .object({
-    currentPassword: z
+    originalPassword: z
       .string()
-      .min(1, { message: '현재 비밀번호를 입력해주세요.' }),
+      .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+      .regex(
+        /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~!@#$%^&*])[a-zA-Z0-9~!@#$%^&*]{8,15}$/,
+        { message: '비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.' },
+      ),
     newPassword: z
       .string()
       .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
@@ -29,12 +34,14 @@ const changePasswordSchema = z
   });
 
 const defaultValues = {
-  currentPassword: '',
+  originalPassword: '',
   newPassword: '',
   confirmNewPassword: '',
 };
 
 const ChangePasswordForm = () => {
+  const mutation = useChangePasswordMutation();
+
   const {
     register,
     handleSubmit,
@@ -46,18 +53,24 @@ const ChangePasswordForm = () => {
   });
 
   const onSubmit = (data: z.infer<typeof changePasswordSchema>) => {
-    // TODO: 비밀번호 변경 API 호출
-    console.log(data);
+    mutation.mutate(data, {
+      onSuccess: () => {
+        alert('비밀번호 변경이 완료되었습니다.');
+      },
+      onError: () => {
+        alert('현재 비밀번호를 다시 확인해주세요.');
+      },
+    });
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles.formWrapper}>
       <Input
-        {...register('currentPassword')}
+        {...register('originalPassword')}
         type="password"
         label="현재 비밀번호"
         placeholder="현재 비밀번호를 입력해주세요"
-        message={errors.currentPassword?.message}
+        message={errors.originalPassword?.message}
       />
 
       <div className={styles.newPasswordWrapper}>

--- a/apps/community/src/components/my/my-info-card.css.ts
+++ b/apps/community/src/components/my/my-info-card.css.ts
@@ -1,5 +1,5 @@
-import { screen, themeVars } from '@aics-client/design-system/styles';
-import { style, styleVariants } from '@vanilla-extract/css';
+import { themeVars } from '@aics-client/design-system/styles';
+import { style } from '@vanilla-extract/css';
 
 const cardWrapper = style({
   display: 'flex',
@@ -18,17 +18,10 @@ const cardTitle = style({
   fontWeight: themeVars.fontWeight.bold,
 });
 
-const cardContent = styleVariants({
-  default: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(2, 1fr)',
-    gap: themeVars.spacing.lg,
-  },
-  singleColumn: {
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    gap: themeVars.spacing.lg,
-  },
+const cardContent = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: themeVars.spacing.lg,
 });
 
 const field = style({
@@ -47,31 +40,9 @@ const editFieldWrapper = style({
   justifyContent: 'space-between',
 });
 
-const editFieldContent = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: themeVars.spacing.lg,
-
-  ...screen.md({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  }),
-});
-
 const editField = style({
-  width: '15rem',
-
-  ...screen.md({
-    width: '20rem',
-  }),
-});
-
-const buttonWrapper = style({
-  display: 'flex',
-  margin: '1rem 0',
-  gap: themeVars.spacing.sm,
+  margin: '1.5rem 0',
+  width: '20rem',
 });
 
 export {
@@ -81,7 +52,5 @@ export {
   field,
   fieldTitle,
   editFieldWrapper,
-  editFieldContent,
   editField,
-  buttonWrapper,
 };

--- a/apps/community/src/components/my/my-info-card.tsx
+++ b/apps/community/src/components/my/my-info-card.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { Button, Input } from '@aics-client/design-system';
-import { useState } from 'react';
+import { Input } from '@aics-client/design-system';
+import type { UseFormRegisterReturn } from 'react-hook-form';
 import * as styles from '~/components/my/my-info-card.css';
 
 interface MyInfoCardProps {
   title: string;
-  layout?: 'default' | 'singleColumn';
   children: React.ReactNode;
 }
 
@@ -16,14 +15,15 @@ interface MyInfoFieldProps {
 }
 
 interface MyInfoEditableFieldProps extends MyInfoFieldProps {
-  onSave?: (value: string) => void;
+  register?: UseFormRegisterReturn;
+  error?: string;
 }
 
-function MyInfoCard({ title, children, layout = 'default' }: MyInfoCardProps) {
+function MyInfoCard({ title, children }: MyInfoCardProps) {
   return (
     <div className={styles.cardWrapper}>
       <h2 className={styles.cardTitle}>{title}</h2>
-      <div className={styles.cardContent[layout]}>{children}</div>
+      <div className={styles.cardContent}>{children}</div>
     </div>
   );
 }
@@ -40,46 +40,20 @@ function MyInfoField({ title, value }: MyInfoFieldProps) {
 function MyInfoEditableField({
   title,
   value,
-  onSave,
+  register,
+  error,
 }: MyInfoEditableFieldProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [currentValue, setCurrentValue] = useState(value);
-
-  const handleEditToggle = () => setIsEditing((prev) => !prev);
-  const handleSave = () => {
-    setIsEditing(false);
-    onSave?.(currentValue);
-  };
-
   return (
     <div className={styles.editFieldWrapper}>
-      <div className={styles.editFieldContent}>
+      <div>
         <h3 className={styles.fieldTitle}>{title}</h3>
         <Input
           className={styles.editField}
           type="text"
-          value={currentValue}
-          placeholder={value}
-          onChange={(e) => setCurrentValue(e.target.value)}
-          disabled={!isEditing}
+          defaultValue={value}
+          message={error}
+          {...register}
         />
-      </div>
-
-      <div className={styles.buttonWrapper}>
-        {isEditing ? (
-          <>
-            <Button size="sm" color="outline" onClick={handleSave}>
-              저장
-            </Button>
-            <Button size="sm" color="outline" onClick={handleEditToggle}>
-              취소
-            </Button>
-          </>
-        ) : (
-          <Button size="sm" color="outline" onClick={handleEditToggle}>
-            변경
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/apps/community/src/components/my/my-info-editable-profile-card.tsx
+++ b/apps/community/src/components/my/my-info-editable-profile-card.tsx
@@ -11,7 +11,7 @@ import { useEditProfileMutation } from '~/hooks/use-edit-profile-mutation';
 interface EditableDetail {
   title: string;
   value: string;
-  field: string;
+  field: keyof FormValues;
 }
 
 interface Props {
@@ -64,12 +64,8 @@ function MyInfoEditableProfileCard({ data }: Props) {
             key={detail.field}
             title={detail.title}
             value={detail.value}
-            register={register(detail.field as keyof FormValues)}
-            error={
-              isSubmitted
-                ? errors[detail.field as keyof FormValues]?.message
-                : ''
-            }
+            register={register(detail.field)}
+            error={isSubmitted ? errors[detail.field]?.message : ''}
           />
         ))}
         <Button size="sm" color="black" disabled={!isDirty} type="submit">

--- a/apps/community/src/components/my/my-info-editable-profile-card.tsx
+++ b/apps/community/src/components/my/my-info-editable-profile-card.tsx
@@ -1,43 +1,81 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { Button } from '@aics-client/design-system';
 import { MyInfoCard } from '~/components/my/my-info-card';
 import { useEditProfileMutation } from '~/hooks/use-edit-profile-mutation';
 
-interface Props {
-  data: {
-    title: string;
-    value: string;
-  }[];
+interface EditableDetail {
+  title: string;
+  value: string;
+  field: string;
 }
 
+interface Props {
+  data: EditableDetail[];
+}
+
+const schema = z.object({
+  phone: z
+    .string()
+    .min(1, { message: '전화번호를 입력해주세요.' })
+    .regex(/^\d{3}-\d{4}-\d{4}$/, {
+      message: '전화번호는 010-1234-5678 형식이어야 합니다.',
+    }),
+  email: z.string().email({ message: '올바른 이메일 형식이 아닙니다.' }),
+});
+
+type FormValues = z.infer<typeof schema>;
+
 function MyInfoEditableProfileCard({ data }: Props) {
-  const { mutate: editProfile } = useEditProfileMutation();
+  const mutation = useEditProfileMutation();
 
-  const updatedData = {
-    phone: data.find((item) => item.title === '전화번호')?.value ?? '',
-    email: data.find((item) => item.title === '이메일')?.value ?? '',
-  };
+  const defaultValues = data.reduce(
+    (acc, { field, value }) => {
+      acc[field] = value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
 
-  const handleSave = (field: string, value: string) => {
-    if (field === '전화번호') {
-      updatedData.phone = value;
-    } else if (field === '이메일') {
-      updatedData.email = value;
-    }
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty, isSubmitted },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues,
+    mode: 'onChange',
+  });
 
-    editProfile(updatedData);
+  const handleFormSubmit = (formData: FormValues) => {
+    mutation.mutate(formData);
+    alert('회원 정보가 수정되었습니다.');
   };
 
   return (
-    <MyInfoCard title="기본 정보" layout="singleColumn">
-      {data.map((detail) => (
-        <MyInfoCard.EditableField
-          key={detail.title}
-          title={detail.title}
-          value={detail.value}
-          onSave={(value) => handleSave(detail.title, value)}
-        />
-      ))}
+    <MyInfoCard title="기본 정보">
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        {data.map((detail) => (
+          <MyInfoCard.EditableField
+            key={detail.field}
+            title={detail.title}
+            value={detail.value}
+            register={register(detail.field as keyof FormValues)}
+            error={
+              isSubmitted
+                ? errors[detail.field as keyof FormValues]?.message
+                : ''
+            }
+          />
+        ))}
+        <Button size="sm" color="black" disabled={!isDirty} type="submit">
+          저장
+        </Button>
+      </form>
     </MyInfoCard>
   );
 }

--- a/apps/community/src/components/my/my-info-profile-card.tsx
+++ b/apps/community/src/components/my/my-info-profile-card.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 function MyInfoProfileCard({ data }: Props) {
   return (
-    <MyInfoCard title="내 프로필" layout="default">
+    <MyInfoCard title="내 프로필">
       {data.map((detail) => (
         <MyInfoCard.Field
           key={detail.title}

--- a/apps/community/src/components/my/my-information.css.ts
+++ b/apps/community/src/components/my/my-information.css.ts
@@ -1,0 +1,15 @@
+import { screen, themeVars } from '@aics-client/design-system/styles';
+import { style } from '@vanilla-extract/css';
+
+const cardWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+
+  ...screen.md({
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: themeVars.spacing.md,
+  }),
+});
+
+export { cardWrapper };

--- a/apps/community/src/components/my/my-information.tsx
+++ b/apps/community/src/components/my/my-information.tsx
@@ -6,6 +6,7 @@ import { MY_PROFILE_QUERY_OPTIONS } from '~/apis/my/queries';
 
 import { MyInfoEditableProfileCard } from './my-info-editable-profile-card';
 import { MyInfoProfileCard } from './my-info-profile-card';
+import * as styles from './my-information.css';
 
 function MyInformation() {
   const { data } = useSuspenseQuery(MY_PROFILE_QUERY_OPTIONS.PROFILE());
@@ -18,15 +19,15 @@ function MyInformation() {
   ];
 
   const userEditableDetails = [
-    { title: '전화번호', value: data.phone },
-    { title: '이메일', value: data.email },
+    { title: '전화번호', value: data.phone, field: 'phone' },
+    { title: '이메일', value: data.email, field: 'email' },
   ];
 
   return (
-    <>
+    <div className={styles.cardWrapper}>
       <MyInfoProfileCard data={userDetails} />
       <MyInfoEditableProfileCard data={userEditableDetails} />
-    </>
+    </div>
   );
 }
 

--- a/apps/community/src/components/my/my-information.tsx
+++ b/apps/community/src/components/my/my-information.tsx
@@ -19,8 +19,8 @@ function MyInformation() {
   ];
 
   const userEditableDetails = [
-    { title: '전화번호', value: data.phone, field: 'phone' },
-    { title: '이메일', value: data.email, field: 'email' },
+    { title: '전화번호', value: data.phone, field: 'phone' as const },
+    { title: '이메일', value: data.email, field: 'email' as const },
   ];
 
   return (

--- a/apps/community/src/components/page-header.tsx
+++ b/apps/community/src/components/page-header.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Fragment } from 'react';
 

--- a/apps/community/src/constants/api.ts
+++ b/apps/community/src/constants/api.ts
@@ -29,6 +29,7 @@ const END_POINT = {
   CLUBS: `${API_BASE_URL}/clubs`,
   MY_PROFILE: `${API_BASE_URL}/users/my`,
   EDIT_MY_PROFILE: `${API_BASE_URL}/users`,
+  CHANGE_PASSWORD: `${API_BASE_URL}/users/password`,
 };
 
 const ACCESS_TOKEN_KEY = 'accessToken';

--- a/apps/community/src/constants/path.ts
+++ b/apps/community/src/constants/path.ts
@@ -22,6 +22,7 @@ const PATHMAP = {
   notice: '공지 사항',
   news: '학부 소식',
   my: '마이페이지',
+  'change-password': '비밀번호 변경',
 } as const;
 
 export { PATH, PATHMAP, type pathmapKey };

--- a/apps/community/src/hooks/use-change-password-mutation.ts
+++ b/apps/community/src/hooks/use-change-password-mutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { MY_PROFILE_QUERY_KEYS } from '~/apis/my/queries';
+import { type MyPassword, patchChangePassword } from '~/apis/my/remotes';
+
+export const useChangePasswordMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: MyPassword) => patchChangePassword(data),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: MY_PROFILE_QUERY_KEYS.PROFILE(),
+      });
+    },
+
+    onError: (e) => {
+      console.log(e);
+    },
+  });
+};


### PR DESCRIPTION
## Summary

> - #66 

마이페이지 관련 api를 연결했어요.

## Tasks

- 개인정보 수정 기능 리팩토링 (일괄적 수정으로)
- 마이 페이지(회원정보 페이지) UI 수정
- 비밀번호 변경 api 연동


## To Reviewer

- 개인정보 수정이 일괄 수정 방식으로 변경되면서 폼 형태로 개편하고, react-hook-form을 적용했어요.
- 기존 마이페이지의 불필요한 여백을 줄여서 더 나은 사용자 경험을 기대하고 있어요. 스크린샷을 첨부하니 더욱 나은 방향이 있다면 코멘트 남겨주시면 감사하겠습니다 :-)



## Screenshot

### before

<img width="1290" alt="393183063-b098cba9-9e33-4476-a82f-99ef1f61c86c" src="https://github.com/user-attachments/assets/5d323559-115c-466a-b67c-175939d1432c" />

### after

https://github.com/user-attachments/assets/d71f4394-1ad2-4b9f-845f-2ce2678b3c1e