### PR TITLE
feat(admin): 공지사항 리스트 페이지 추가

### DIFF
--- a/apps/admin/src/apis/admin/queries/common.ts
+++ b/apps/admin/src/apis/admin/queries/common.ts
@@ -69,7 +69,7 @@ export type PostServicePatchApiV1PostsByPostIdPinMutationResult = Awaited<
   ReturnType<typeof PostService.patchApiV1PostsByPostIdPin>
 >;
 export type PostServicePatchApiV1PostsByPostIdDeleteMutationResult = Awaited<
-  ReturnType<typeof PostService.patchApiV1PostsByPostIdDelete>
+  ReturnType<typeof PostService.deleteApiV1PostsByPostIdDelete>
 >;
 export type LabServicePatchApiV1LabsByIdMutationResult = Awaited<
   ReturnType<typeof LabService.patchApiV1LabsById>

--- a/apps/admin/src/apis/admin/queries/queries.ts
+++ b/apps/admin/src/apis/admin/queries/queries.ts
@@ -458,7 +458,7 @@ export const usePostServicePatchApiV1PostsByPostIdPin = <
       }) as unknown as Promise<TData>,
     ...options,
   });
-export const usePostServicePatchApiV1PostsByPostIdDelete = <
+export const useDeletePost = <
   TData = Common.PostServicePatchApiV1PostsByPostIdDeleteMutationResult,
   TError = unknown,
   TContext = unknown,
@@ -484,7 +484,7 @@ export const usePostServicePatchApiV1PostsByPostIdDelete = <
     TContext
   >({
     mutationFn: ({ postId }) =>
-      PostService.patchApiV1PostsByPostIdDelete({
+      PostService.deleteApiV1PostsByPostIdDelete({
         postId,
       }) as unknown as Promise<TData>,
     ...options,

--- a/apps/admin/src/apis/admin/requests/services.gen.ts
+++ b/apps/admin/src/apis/admin/requests/services.gen.ts
@@ -203,11 +203,11 @@ export class PostService {
    * @returns void No Content
    * @throws ApiError
    */
-  public static patchApiV1PostsByPostIdDelete(
+  public static deleteApiV1PostsByPostIdDelete(
     data: PatchApiV1PostsByPostIdDeleteData,
   ): CancelablePromise<PatchApiV1PostsByPostIdDeleteResponse> {
     return __request(OpenAPI, {
-      method: 'PATCH',
+      method: 'DELETE',
       url: '/api/v1/posts/{postId}/delete',
       path: {
         postId: data.postId,

--- a/apps/admin/src/apis/community/queries/common.ts
+++ b/apps/admin/src/apis/community/queries/common.ts
@@ -67,7 +67,7 @@ export const UsePostServiceGetApiV1PostsKeyFn = (
     size,
   }: {
     category?: 'NOTIFICATION' | 'NEWS';
-    keywords?: string[];
+    keywords?: string;
     page: number;
     size: number;
   },

--- a/apps/admin/src/apis/community/queries/ensureQueryData.ts
+++ b/apps/admin/src/apis/community/queries/ensureQueryData.ts
@@ -47,7 +47,7 @@ export const ensureUsePostServiceGetApiV1PostsData = (
     size,
   }: {
     category?: 'NOTIFICATION' | 'NEWS';
-    keywords?: string[];
+    keywords?: string;
     page: number;
     size: number;
   },

--- a/apps/admin/src/apis/community/queries/prefetch.ts
+++ b/apps/admin/src/apis/community/queries/prefetch.ts
@@ -47,7 +47,7 @@ export const prefetchUsePostServiceGetApiV1Posts = (
     size,
   }: {
     category?: 'NOTIFICATION' | 'NEWS';
-    keywords?: string[];
+    keywords?: string;
     page: number;
     size: number;
   },

--- a/apps/admin/src/apis/community/queries/queries.ts
+++ b/apps/admin/src/apis/community/queries/queries.ts
@@ -83,7 +83,7 @@ export const usePostServiceGetApiV1Posts = <
     size,
   }: {
     category?: 'NOTIFICATION' | 'NEWS';
-    keywords?: string[];
+    keywords?: string;
     page: number;
     size: number;
   },

--- a/apps/admin/src/apis/community/queries/suspense.ts
+++ b/apps/admin/src/apis/community/queries/suspense.ts
@@ -71,7 +71,7 @@ export const usePostServiceGetApiV1PostsSuspense = <
     size,
   }: {
     category?: 'NOTIFICATION' | 'NEWS';
-    keywords?: string[];
+    keywords?: string;
     page: number;
     size: number;
   },

--- a/apps/admin/src/apis/community/requests/types.gen.ts
+++ b/apps/admin/src/apis/community/requests/types.gen.ts
@@ -491,7 +491,7 @@ export type GetApiV1PostsData = {
   /**
    * 검색 키워드 입니다. 미 입력 시 전체 게시글을 조회합니다.
    */
-  keywords?: Array<string>;
+  keywords?: string;
   /**
    * 페이지 인덱스
    */

--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 
 import LOGO from '~/assets/logo.svg';
+import { PATH } from '~/constants/path';
 import { useRefreshTokens } from '~/hooks/use-refresh-token';
 import { useTokenExpiration } from '~/hooks/use-token-expiration';
 import { authServices } from '~/utils/auth';
@@ -49,7 +50,7 @@ const items: MenuItem[] = [
     label: '게시판',
     icon: <Clipboard size={20} />,
     children: [
-      { key: 'notice', label: <Link to="/">공지사항</Link> },
+      { key: 'notice', label: <Link to={PATH.NOTICE}>공지사항</Link> },
       { key: 'news', label: <Link to="/">학부 소식</Link> },
     ],
   },
@@ -77,7 +78,7 @@ function AsideFooter() {
   };
 
   return (
-    <div className="flex items-center text-sm p-2 border-r border-gray-200 justify-between">
+    <div className="flex items-center justify-between p-2 text-sm border-r border-gray-200">
       <div className="flex gap-1.5 items-center">
         <Clock size={16} />
         <span>{formatExpireTime(expireTime)}</span>
@@ -85,14 +86,14 @@ function AsideFooter() {
       <div>
         <button
           type="button"
-          className="p-2  transition-colors duration-150 rounded-md cursor-pointer hover:bg-gray-300"
+          className="p-2 transition-colors duration-150 rounded-md cursor-pointer hover:bg-gray-300"
           onClick={handleRefreshToken}
         >
           시간연장
         </button>
         <button
           type="button"
-          className="p-2  transition-colors duration-150 rounded-md cursor-pointer hover:bg-gray-300"
+          className="p-2 transition-colors duration-150 rounded-md cursor-pointer hover:bg-gray-300"
           onClick={logout}
         >
           로그아웃

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -2,10 +2,10 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import {
   Button,
   List,
-  message,
   Modal,
   Pagination,
   type PaginationProps,
+  message,
 } from 'antd';
 import { Pin, Trash2Icon } from 'lucide-react';
 import { useDeletePost } from '~/apis/admin/queries';

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -12,14 +12,14 @@ import { useDeletePost } from '~/apis/admin/queries';
 import type { PostSummaryResponse } from '~/apis/community/requests';
 import useModal from '~/hooks/use-modal';
 
-function DeleteButton({ selected }: { selected: number }) {
+function DeleteButton({ postId }: { postId: number }) {
   const { isOpen, openModal, closeModal } = useModal();
   const { mutate } = useDeletePost();
   const [messageApi, contextHolder] = message.useMessage();
 
   const handleDelete = () => {
     mutate(
-      { postId: selected },
+      { postId: postId },
       {
         onSuccess: () => {
           closeModal();
@@ -92,7 +92,7 @@ function PostListItem({ post, to }: PostListItemProps) {
         <span className="text-black">{post.title}</span>
         <span className="text-black">{post.createdAt}</span>
       </Link>
-      <DeleteButton selected={post.postId} />
+      <DeleteButton postId={post.postId} />
     </List.Item>
   );
 }

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -1,5 +1,12 @@
 import { Link, useNavigate } from '@tanstack/react-router';
-import { Button, List, Modal, Pagination, type PaginationProps } from 'antd';
+import {
+  Button,
+  List,
+  message,
+  Modal,
+  Pagination,
+  type PaginationProps,
+} from 'antd';
 import { Pin, Trash2Icon } from 'lucide-react';
 import { useDeletePost } from '~/apis/admin/queries';
 import type { PostSummaryResponse } from '~/apis/community/requests';
@@ -8,6 +15,7 @@ import useModal from '~/hooks/use-modal';
 function DeleteButton({ selected }: { selected: number }) {
   const { isOpen, openModal, closeModal } = useModal();
   const { mutate } = useDeletePost();
+  const [messageApi, contextHolder] = message.useMessage();
 
   const handleDelete = () => {
     mutate(
@@ -15,6 +23,17 @@ function DeleteButton({ selected }: { selected: number }) {
       {
         onSuccess: () => {
           closeModal();
+          messageApi.open({
+            type: 'success',
+            content: '게시글이 성공적으로 삭제되었습니다.',
+          });
+        },
+        onError: () => {
+          closeModal();
+          messageApi.open({
+            type: 'error',
+            content: '게시글 삭제에 실패했습니다.',
+          });
         },
       },
     );
@@ -22,6 +41,7 @@ function DeleteButton({ selected }: { selected: number }) {
 
   return (
     <>
+      {contextHolder}
       <button
         type="button"
         className="p-1 transition-colors duration-150 rounded-lg cursor-pointer hover:bg-red-300"

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -1,0 +1,118 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+import { Button, List, Modal, Pagination, type PaginationProps } from 'antd';
+import { Pin, Trash2Icon } from 'lucide-react';
+import { useDeletePost } from '~/apis/admin/queries';
+import type { PostSummaryResponse } from '~/apis/community/requests';
+import useModal from '~/hooks/use-modal';
+
+function DeleteButton({ selected }: { selected: number }) {
+  const { isOpen, openModal, closeModal } = useModal();
+  const { mutate } = useDeletePost();
+
+  const handleDelete = () => {
+    mutate(
+      { postId: selected },
+      {
+        onSuccess: () => {
+          closeModal();
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="p-1 transition-colors duration-150 rounded-lg cursor-pointer hover:bg-red-300"
+        onClick={openModal}
+      >
+        <Trash2Icon color="red" />
+      </button>
+      <Modal
+        open={isOpen}
+        onCancel={closeModal}
+        footer={
+          <>
+            <Button color="danger" variant="solid" onClick={handleDelete}>
+              삭제
+            </Button>
+            <Button color="default" variant="outlined" onClick={closeModal}>
+              취소
+            </Button>
+          </>
+        }
+        width={500}
+      >
+        정말 삭제하시겠습니까?
+      </Modal>
+    </>
+  );
+}
+interface PostListItemProps {
+  post: PostSummaryResponse;
+  to: string;
+}
+
+function PostListItem({ post, to }: PostListItemProps) {
+  return (
+    <List.Item className="flex items-center gap-3 transition-colors duration-100 hover:bg-gray-50">
+      <Link
+        to={`${to}${post.postId.toString()}`}
+        className="flex justify-between w-full p-1"
+      >
+        <div className="flex items-center">
+          {post.isPinned ? (
+            <Pin fill="black" size={'1.25rem'} />
+          ) : (
+            <span className="text-black">{post.postId}</span>
+          )}
+        </div>
+        <span className="text-black">{post.title}</span>
+        <span className="text-black">{post.createdAt}</span>
+      </Link>
+      <DeleteButton selected={post.postId} />
+    </List.Item>
+  );
+}
+
+interface PostListProps {
+  title: string;
+  to: string;
+  currentPage: number;
+  data: PostSummaryResponse[];
+  total: number;
+}
+
+function PostsList({ title, to, currentPage, data, total }: PostListProps) {
+  const navigate = useNavigate({ from: '/notice' });
+
+  const handlePageChange: PaginationProps['onChange'] = (currentPage) => {
+    navigate({
+      search: (prev) => ({ ...prev, page: currentPage - 1 }),
+    });
+  };
+
+  return (
+    <>
+      <List
+        header={<div className="text-lg font-semibold">{title}</div>}
+        itemLayout="horizontal"
+        bordered
+        size="large"
+        dataSource={data}
+        renderItem={(post) => <PostListItem to={to} post={post} />}
+      />
+      <Pagination
+        align="center"
+        showSizeChanger={false}
+        defaultCurrent={1}
+        current={currentPage + 1}
+        total={total}
+        onChange={handlePageChange}
+      />
+    </>
+  );
+}
+
+export default PostsList;

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -12,29 +12,33 @@ import { useDeletePost } from '~/apis/admin/queries';
 import type { PostSummaryResponse } from '~/apis/community/requests';
 import useModal from '~/hooks/use-modal';
 
-function DeleteButton({ postId }: { postId: number }) {
+function DeleteButton({ postId, title }: { postId: number; title: string }) {
   const { isOpen, openModal, closeModal } = useModal();
   const { mutate } = useDeletePost();
   const [messageApi, contextHolder] = message.useMessage();
+
+  const handleSuccess = () => {
+    closeModal();
+    messageApi.open({
+      type: 'success',
+      content: '게시글이 성공적으로 삭제되었습니다.',
+    });
+  };
+
+  const handleError = () => {
+    closeModal();
+    messageApi.open({
+      type: 'error',
+      content: '게시글 삭제에 실패했습니다.',
+    });
+  };
 
   const handleDelete = () => {
     mutate(
       { postId: postId },
       {
-        onSuccess: () => {
-          closeModal();
-          messageApi.open({
-            type: 'success',
-            content: '게시글이 성공적으로 삭제되었습니다.',
-          });
-        },
-        onError: () => {
-          closeModal();
-          messageApi.open({
-            type: 'error',
-            content: '게시글 삭제에 실패했습니다.',
-          });
-        },
+        onSuccess: handleSuccess,
+        onError: handleError,
       },
     );
   };
@@ -52,7 +56,7 @@ function DeleteButton({ postId }: { postId: number }) {
       <Modal
         open={isOpen}
         onCancel={closeModal}
-        title="게시글 삭제"
+        title={title}
         footer={
           <>
             <Button color="danger" variant="solid" onClick={handleDelete}>
@@ -70,6 +74,7 @@ function DeleteButton({ postId }: { postId: number }) {
     </>
   );
 }
+
 interface PostListItemProps {
   post: PostSummaryResponse;
   to: string;
@@ -92,7 +97,7 @@ function PostListItem({ post, to }: PostListItemProps) {
         <span className="text-black">{post.title}</span>
         <span className="text-black">{post.createdAt}</span>
       </Link>
-      <DeleteButton postId={post.postId} />
+      <DeleteButton postId={post.postId} title={post.title} />
     </List.Item>
   );
 }

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -32,6 +32,7 @@ function DeleteButton({ selected }: { selected: number }) {
       <Modal
         open={isOpen}
         onCancel={closeModal}
+        title="게시글 삭제"
         footer={
           <>
             <Button color="danger" variant="solid" onClick={handleDelete}>

--- a/apps/admin/src/components/posts/search-bar.tsx
+++ b/apps/admin/src/components/posts/search-bar.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from '@tanstack/react-router';
+import { SearchIcon } from 'lucide-react';
+import { useState } from 'react';
+
+interface SearchBarProps {
+  defaultValue: string;
+}
+
+function SearchBar({ defaultValue }: SearchBarProps) {
+  const [searchText, setSearchText] = useState('');
+  const navigate = useNavigate({ from: '/notice' });
+
+  const handleSearch = (keyword: string) => {
+    navigate({
+      search: (prev) => ({ ...prev, query: keyword }),
+    });
+  };
+
+  const handlePressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch(searchText);
+    }
+  };
+
+  return (
+    <div className="self-center min-w-[40vw] gap-4 p-2 flex justify-between items-center border border-gray-300 rounded-lg">
+      <input
+        type="text"
+        defaultValue={defaultValue}
+        onChange={(e) => setSearchText(e.target.value)}
+        onKeyUp={handlePressEnter}
+        placeholder="검색어를 입력하세요"
+        className="w-full p-1 outline-none"
+      />
+      <button
+        type="button"
+        onClick={() => handleSearch(searchText)}
+        className="p-1 transition-colors duration-150 rounded-lg cursor-pointer hover:bg-gray-200"
+      >
+        <SearchIcon />
+      </button>
+    </div>
+  );
+}
+
+export { SearchBar };

--- a/apps/admin/src/constants/path.ts
+++ b/apps/admin/src/constants/path.ts
@@ -1,0 +1,6 @@
+export const PATH = {
+  SIGNIN: '/',
+  MAIN: '/main',
+  NEWS: '/news/',
+  NOTICE: '/notice/',
+};

--- a/apps/admin/src/hooks/use-modal.ts
+++ b/apps/admin/src/hooks/use-modal.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  return {
+    isOpen,
+    openModal,
+    closeModal,
+  };
+};
+
+export default useModal;

--- a/apps/admin/src/routes/__root.tsx
+++ b/apps/admin/src/routes/__root.tsx
@@ -22,9 +22,9 @@ function App() {
         },
       }}
     >
-      <main className="relative flex h-dvh">
+      <main className="relative flex w-dvw h-dvh">
         {!isSigninPage && <AsideNavigationMenu />}
-        <div className="flex flex-col items-center justify-center w-full h-full">
+        <div className="flex flex-col justify-center w-full h-full">
           <Outlet />
         </div>
         <TanStackRouterDevtools position="top-right" />

--- a/apps/admin/src/routes/lab/index.tsx
+++ b/apps/admin/src/routes/lab/index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/lab/')({
 
 function LabPage() {
   return (
-    <section className="py-10 px-16">
+    <section>
       <Button type="primary" className="mb-4">
         연구실 추가하기
       </Button>

--- a/apps/admin/src/routes/notice/index.tsx
+++ b/apps/admin/src/routes/notice/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useSearch } from '@tanstack/react-router';
+import { Suspense } from 'react';
 
-import { usePostServiceGetApiV1Posts } from '~/apis/community/queries';
+import { usePostServiceGetApiV1PostsSuspense } from '~/apis/community/queries/suspense';
 
 import PostsList from '~/components/posts/posts-list';
 import { SearchBar } from '~/components/posts/search-bar';
@@ -22,7 +23,7 @@ function NewsListPage() {
     from: '/notice/',
   });
 
-  const { data: postList } = usePostServiceGetApiV1Posts({
+  const { data: postList } = usePostServiceGetApiV1PostsSuspense({
     category: CATEGORY,
     size: LIST_SIZE,
     keywords: keywords,
@@ -31,16 +32,18 @@ function NewsListPage() {
 
   return (
     <section className="flex flex-col gap-3 px-16">
-      <SearchBar defaultValue={keywords} />
-      {postList?.contents && (
-        <PostsList
-          title="공지사항"
-          to={PATH.NOTICE}
-          currentPage={currentPage}
-          data={postList.contents}
-          total={postList.pageable.totalElements}
-        />
-      )}
+      <Suspense fallback={<div>loading...</div>}>
+        <SearchBar defaultValue={keywords} />
+        {postList?.contents && (
+          <PostsList
+            title="공지사항"
+            to={PATH.NOTICE}
+            currentPage={currentPage}
+            data={postList.contents}
+            total={postList.pageable.totalElements}
+          />
+        )}
+      </Suspense>
     </section>
   );
 }

--- a/apps/admin/src/routes/notice/index.tsx
+++ b/apps/admin/src/routes/notice/index.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+
+import { usePostServiceGetApiV1Posts } from '~/apis/community/queries';
+
+import PostsList from '~/components/posts/posts-list';
+import { SearchBar } from '~/components/posts/search-bar';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/notice/')({
+  component: NewsListPage,
+  validateSearch: (search: { page?: string; query?: string }) => ({
+    page: Number(search.page) || 0,
+    query: typeof search.query === 'string' ? search.query : '', // 기본값 ''
+  }),
+});
+
+const CATEGORY = 'NOTIFICATION';
+const LIST_SIZE = 10;
+
+function NewsListPage() {
+  const { page: currentPage, query: keywords } = useSearch({
+    from: '/notice/',
+  });
+
+  const { data: postList } = usePostServiceGetApiV1Posts({
+    category: CATEGORY,
+    size: LIST_SIZE,
+    keywords: keywords,
+    page: currentPage,
+  });
+
+  return (
+    <section className="flex flex-col gap-3 px-16">
+      <SearchBar defaultValue={keywords} />
+      {postList?.contents && (
+        <PostsList
+          title="공지사항"
+          to={PATH.NOTICE}
+          currentPage={currentPage}
+          data={postList.contents}
+          total={postList.pageable.totalElements}
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/admin/src/routes/notice/index.tsx
+++ b/apps/admin/src/routes/notice/index.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute('/notice/')({
   component: NewsListPage,
   validateSearch: (search: { page?: string; query?: string }) => ({
     page: Number(search.page) || 0,
-    query: typeof search.query === 'string' ? search.query : '', // 기본값 ''
+    query: typeof search.query === 'string' ? search.query : '',
   }),
 });
 


### PR DESCRIPTION
## Summary

> resolved #85 

공지사항 리스트 페이지를 추가하였어요.

## Tasks

- 공지사항 리스트 페이지 추가
    - 검색 및 삭제 기능


## To Reviewer

일괄 삭제 기능은 api 여건 상 추가하지 못하였어요, 따라서 현재는 `삭제(쓰레기통) 버튼 클릭 -> modal 오픈 (정말 삭제하시겠습니까?) -> 게시글 삭제` 의 흐름으로 하나씩 삭제할 수 있게끔 구현하였어요. 혹시 다른 좋은 아이디어가 있다면 말씀해주세요!

추가적으로 modal은 커스텀 훅인 `use-modal`을 통해 관리하도록 하였어요.

🚨🚨***제안 사항이 있어요!***
프로젝트 전반적으로 `useSuspenseQuery`와 `Suspense`를 사용하는 것은 어떨까요?


## Screenshot
> 게시글 리스트 화면

![image](https://github.com/user-attachments/assets/5b8abceb-b0dd-4c01-9b5f-8e0f00f15c6e)

> 삭제 안내 모달

![image](https://github.com/user-attachments/assets/12cfe8d5-17a5-4fab-9eee-7898017e8880)

