### PR TITLE
feat(admin): 학부소식 리스트 페이지 추가

### DIFF
--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -51,7 +51,7 @@ const items: MenuItem[] = [
     icon: <Clipboard size={20} />,
     children: [
       { key: 'notice', label: <Link to={PATH.NOTICE}>공지사항</Link> },
-      { key: 'news', label: <Link to="/">학부 소식</Link> },
+      { key: 'news', label: <Link to={PATH.NEWS}>학부 소식</Link> },
     ],
   },
 ];

--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -79,7 +79,7 @@ function AsideFooter() {
 
   return (
     <div className="flex items-center justify-between p-2 text-sm border-r border-gray-200">
-      <div className="flex gap-1.5 items-center">
+      <div className="flex p-2 gap-1.5 items-center">
         <Clock size={16} />
         <span>{formatExpireTime(expireTime)}</span>
       </div>

--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -31,7 +31,7 @@ const items: MenuItem[] = [
     icon: <GraduationCap size={20} />,
     children: [
       { key: 'dept', label: <Link to="/">학부 소개</Link> },
-      { key: 'club', label: <Link to="/club">동아리 소개</Link> },
+      { key: 'club', label: <Link to={PATH.CLUB}>동아리 소개</Link> },
       { key: 'contact', label: <Link to="/">찾아오시는 길</Link> },
     ],
   },

--- a/apps/admin/src/constants/path.ts
+++ b/apps/admin/src/constants/path.ts
@@ -3,4 +3,5 @@ export const PATH = {
   MAIN: '/main',
   NEWS: '/news/',
   NOTICE: '/notice/',
+  CLUB: '/club',
 };

--- a/apps/admin/src/routes/news/index.tsx
+++ b/apps/admin/src/routes/news/index.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+import { Suspense } from 'react';
+
+import { usePostServiceGetApiV1PostsSuspense } from '~/apis/community/queries/suspense';
+
+import PostsList from '~/components/posts/posts-list';
+import { SearchBar } from '~/components/posts/search-bar';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/news/')({
+  component: NewsListPage,
+  validateSearch: (search: { page?: string; query?: string }) => ({
+    page: Number(search.page) || 0,
+    query: typeof search.query === 'string' ? search.query : '',
+  }),
+});
+
+const CATEGORY = 'NEWS';
+const LIST_SIZE = 10;
+
+function NewsListPage() {
+  const { page: currentPage, query: keywords } = useSearch({
+    from: '/news/',
+  });
+
+  const { data: postList } = usePostServiceGetApiV1PostsSuspense({
+    category: CATEGORY,
+    size: LIST_SIZE,
+    keywords: keywords,
+    page: currentPage,
+  });
+
+  return (
+    <section className="flex flex-col gap-3 px-16">
+      <Suspense fallback={<div>loading...</div>}>
+        <SearchBar defaultValue={keywords} />
+        {postList?.contents && (
+          <PostsList
+            title="학부소식"
+            to={PATH.NOTICE}
+            currentPage={currentPage}
+            data={postList.contents}
+            total={postList.pageable.totalElements}
+          />
+        )}
+      </Suspense>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

> resolved #102 

학부 소식 리스트 페이지를 추가하였어요

## Tasks

- 학부 소식 리스트 페이지 추가
    - 검색 / 삭제 기능


## To Reviewer

공지사항 리스트 페이지와 동일해요.


## Screenshot

![image](https://github.com/user-attachments/assets/21802461-8695-4d72-a994-9acf4cb2ad34)

