### PR TITLE
feat(admin): 게시글 상세 페이지

### DIFF
--- a/apps/admin/src/apis/community/queries/suspense.ts
+++ b/apps/admin/src/apis/community/queries/suspense.ts
@@ -87,7 +87,7 @@ export const usePostServiceGetApiV1PostsSuspense = <
       PostService.getApiV1Posts({ category, keywords, page, size }) as TData,
     ...options,
   });
-export const usePostServiceGetApiV1PostsByPostIdSuspense = <
+export const useGetPostById = <
   TData = Common.PostServiceGetApiV1PostsByPostIdDefaultResponse,
   TError = unknown,
   TQueryKey extends Array<unknown> = unknown[],

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -32,7 +32,7 @@ function Header({ title, author, views, createdAt, file }: HeaderProps) {
     <div>
       <h1 className="font-semibold text-4xl p-8 pb-4">{title}</h1>
       <div className="flex justify-between border-t border-gray-200 px-8 pt-4 text-gray-500 text-sm">
-        <div>{author}</div>
+        <p>{author}</p>
         <div className="flex items-center gap-6">
           <div className="flex items-center gap-2 sm:visible invisible">
             <Eye size={'0.875rem'} />

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -1,0 +1,196 @@
+import { Link } from '@tanstack/react-router';
+import { Button, Modal, message } from 'antd';
+import {
+  ArrowLeft,
+  Calendar,
+  Download,
+  Eye,
+  PencilIcon,
+  Trash2Icon,
+} from 'lucide-react';
+import { useDeletePost } from '~/apis/admin/queries';
+import useModal from '~/hooks/use-modal';
+import { extractFileName } from '~/utils/utils';
+
+interface HeaderProps {
+  title: string;
+  author: string;
+  views: number;
+  createdAt: string;
+  file?: {
+    id: number;
+    physicalPath: string;
+  };
+}
+
+function Board({ children }: { children: React.ReactNode }) {
+  return <article>{children}</article>;
+}
+
+function Header({ title, author, views, createdAt, file }: HeaderProps) {
+  return (
+    <div>
+      <h1 className="font-semibold text-4xl p-8 pb-4">{title}</h1>
+      <div className="flex justify-between border-t border-gray-200 px-8 pt-4 text-gray-500 text-sm">
+        <div>{author}</div>
+        <div className="flex items-center gap-6">
+          <div className="flex items-center gap-2 sm:visible invisible">
+            <Eye size={'0.875rem'} />
+            <span>{views}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Calendar size={'0.875rem'} />
+            <span>{createdAt}</span>
+          </div>
+        </div>
+      </div>
+      {file && (
+        <button
+          type="button"
+          className="flex items-center self-end px-4 py-2 text-sm font-semibold gap-2"
+        >
+          <Download size={'0.875rem'} />
+          <span>{extractFileName(file.physicalPath)}</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Content({ content }: { content: string }) {
+  return <div className="px-10 py-8 whitespace-pre-line">{content}</div>;
+}
+
+function DeleteButton({ postId }: { postId: number }) {
+  const { mutate } = useDeletePost();
+  const { isOpen, openModal, closeModal } = useModal();
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const handleSuccess = () => {
+    closeModal();
+    messageApi.open({
+      type: 'success',
+      content: '게시글이 성공적으로 삭제되었습니다.',
+    });
+  };
+
+  const handleError = () => {
+    closeModal();
+    messageApi.open({
+      type: 'error',
+      content: '게시글 삭제에 실패했습니다.',
+    });
+  };
+
+  const handleDelete = () => {
+    mutate(
+      { postId: postId },
+      {
+        onSuccess: handleSuccess,
+        onError: handleError,
+      },
+    );
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Button
+        color="danger"
+        variant="solid"
+        className="flex items-center gap-2 text-sm"
+        onClick={openModal}
+      >
+        <Trash2Icon size={'1rem'} />
+        삭제하기
+      </Button>
+      <Modal
+        open={isOpen}
+        onCancel={closeModal}
+        title="게시글 삭제"
+        footer={
+          <>
+            <Button color="danger" variant="solid" onClick={handleDelete}>
+              삭제
+            </Button>
+            <Button color="default" variant="outlined" onClick={closeModal}>
+              취소
+            </Button>
+          </>
+        }
+        width={500}
+      >
+        정말 삭제하시겠습니까?
+      </Modal>
+    </>
+  );
+}
+
+interface FooterProps {
+  prevPost?: {
+    postId: number;
+    title: string;
+  };
+  nextPost?: {
+    postId: number;
+    title: string;
+  };
+  to: string;
+  postId: number;
+}
+
+function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
+  return (
+    <div className="flex flex-col gap-6 items-start">
+      <div className="w-full flex flex-col border-t border-b border-gray-200">
+        {prevPost ? (
+          <Link
+            to={`${to}${prevPost.postId.toString()}`}
+            className="flex gap-4 p-5 border-b border-gray-200"
+          >
+            <span className="font-semibold">이전</span>
+            <h2>{prevPost.title}</h2>
+          </Link>
+        ) : (
+          <div className="p-5">이전 글이 없습니다</div>
+        )}
+        {nextPost ? (
+          <Link
+            to={`${to}${nextPost.postId.toString()}`}
+            className="flex gap-4 p-5"
+          >
+            <span className="font-semibold">다음</span>
+            <h2>{nextPost.title}</h2>
+          </Link>
+        ) : (
+          <div className="p-5">다음 글이 없습니다.</div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between w-full">
+        <Button className="flex items-center gap-2 text-sm">
+          <ArrowLeft size={'1rem'} />
+          <Link to={to}>목록으로</Link>
+        </Button>
+
+        <div className="flex items-center gap-3">
+          <Button
+            color="primary"
+            variant="solid"
+            className="flex items-center gap-2 text-sm"
+          >
+            <PencilIcon size={'1rem'} />
+            <Link to={to}>수정하기</Link>
+          </Button>
+          <DeleteButton postId={postId} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Board.Header = Header;
+Board.Content = Content;
+Board.Footer = Footer;
+
+export { Board };

--- a/apps/admin/src/routes/news/$postId.tsx
+++ b/apps/admin/src/routes/news/$postId.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute, useMatch } from '@tanstack/react-router';
+import { useGetPostById } from '~/apis/community/queries/suspense';
+import { Board } from '~/components/posts/board';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/news/$postId')({
+  component: PostDetailPage,
+});
+
+function PostDetailPage() {
+  const { params } = useMatch({ from: '/news/$postId' });
+  const { data } = useGetPostById({ postId: Number(params.postId) });
+
+  return (
+    <section className="px-16">
+      <Board>
+        <Board.Header
+          title={data.title}
+          author={data.author}
+          views={data.views}
+          createdAt={data.createdAt}
+          file={data.file}
+        />
+        <Board.Content content={data.content} />
+        <Board.Footer
+          postId={data.postId}
+          prevPost={data.prevPost}
+          nextPost={data.nextPost}
+          to={PATH.NEWS}
+        />
+      </Board>
+    </section>
+  );
+}

--- a/apps/admin/src/routes/news/index.tsx
+++ b/apps/admin/src/routes/news/index.tsx
@@ -37,7 +37,7 @@ function NewsListPage() {
         {postList?.contents && (
           <PostsList
             title="학부소식"
-            to={PATH.NOTICE}
+            to={PATH.NEWS}
             currentPage={currentPage}
             data={postList.contents}
             total={postList.pageable.totalElements}

--- a/apps/admin/src/routes/notice/$postId.tsx
+++ b/apps/admin/src/routes/notice/$postId.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute, useMatch } from '@tanstack/react-router';
+import { useGetPostById } from '~/apis/community/queries/suspense';
+import { Board } from '~/components/posts/board';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/notice/$postId')({
+  component: PostDetailPage,
+});
+
+function PostDetailPage() {
+  const { params } = useMatch({ from: '/notice/$postId' });
+  const { data } = useGetPostById({ postId: Number(params.postId) });
+
+  return (
+    <section className="px-16">
+      <Board>
+        <Board.Header
+          title={data.title}
+          author={data.author}
+          views={data.views}
+          createdAt={data.createdAt}
+          file={data.file}
+        />
+        <Board.Content content={data.content} />
+        <Board.Footer
+          postId={data.postId}
+          prevPost={data.prevPost}
+          nextPost={data.nextPost}
+          to={PATH.NOTICE}
+        />
+      </Board>
+    </section>
+  );
+}

--- a/apps/admin/src/utils/utils.ts
+++ b/apps/admin/src/utils/utils.ts
@@ -7,3 +7,7 @@ export const formatExpireTime = (times: number | null) => {
 
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 };
+
+export const extractFileName = (path: string) => {
+  return path.split('/').pop();
+};


### PR DESCRIPTION
## Summary

> resolved #91 

게시글 상세 페이지를 추가하였어요.

## Tasks

- 게시글 상세 페이지 추가


## To Reviewer

초기에는 게시글 상세 페이지에서 수정까지 함께 처리하기로 하였지만, 보다 명확한 구조를 위해 수정 기능을 별도의 페이지로 분리하기로 하였어요. 따라서 상세 페이지에는 삭제 기능과 수정 페이지로 이동하는 버튼만을 추가했어요.


## Screenshot

![image](https://github.com/user-attachments/assets/e7524988-3be5-490f-a965-a2766c52d8d6)

