### PR TITLE
fix(community): 로그인 폼이 overflow 되는 현상 해결

### DIFF
--- a/apps/community/src/app/(auth)/layout.css.ts
+++ b/apps/community/src/app/(auth)/layout.css.ts
@@ -2,9 +2,10 @@ import { themeVars } from '@aics-client/design-system/styles';
 import { style } from '@vanilla-extract/css';
 
 export const section = style({
-  display: themeVars.display.grid,
+  display: themeVars.display.flex,
+  flexDirection: themeVars.flexDirection.column,
+  alignItems: themeVars.alignItems.center,
   gap: themeVars.spacing.lg,
   margin: '0 auto',
   padding: themeVars.spacing.md,
-  width: '25rem',
 });

--- a/apps/community/src/components/(auth)/signin/sign-in-form.css.ts
+++ b/apps/community/src/components/(auth)/signin/sign-in-form.css.ts
@@ -2,8 +2,11 @@ import { themeVars } from '@aics-client/design-system/styles';
 import { style } from '@vanilla-extract/css';
 
 const formWrapper = style({
-  display: themeVars.display.grid,
+  display: themeVars.display.flex,
+  flexDirection: themeVars.flexDirection.column,
   gap: themeVars.spacing.md,
+  width: themeVars.width.full,
+  maxWidth: '32rem',
 });
 
 const errorMessage = style({

--- a/apps/community/src/components/site-footer.css.ts
+++ b/apps/community/src/components/site-footer.css.ts
@@ -43,7 +43,8 @@ const navLinks = style({
       gridTemplateColumns: 'repeat(auto-fit, minmax(88px, 1fr))',
     },
     'screen and (max-width: 768px)': {
-      gridTemplateColumns: 'repeat(auto-fit, minmax(80px, 1fr))',
+      gap: '1.5rem',
+      gridTemplateColumns: 'repeat(auto-fit, minmax(76px, 1fr))',
     },
   },
 });


### PR DESCRIPTION
## Summary

> fixed #111 

로그인 페이지에서 로그인 폼이 overflow 되는 현상을 해결하였어요.

## Tasks

- sign-in page의 layout 스타일링 변경
- site-footer 내부 간격 조정


## To Reviewer

기존의 sign-in 페이지의 레이아웃은 `grid`로 설정되어있었으나, 해당 레이아웃에는 `flex-column`이 적절하다고 판단되어 변경하였고, 고정 width값을 삭제하였어요.

**현재 서버 문제로 인하여 ci 에러가 발생한 상황이에요. 이후에 자연스레 해결 될 예정입니다!!**

## Screenshot

> 문제의 레이아웃

![image](https://github.com/user-attachments/assets/d94791ec-f644-4dc4-9406-4fe90d45c522)

> 해결

![image](https://github.com/user-attachments/assets/acb5d93d-f83f-4e87-90a2-b789b98de187)

