### PR TITLE
feat(admin): 게시물 작성 페이지 추가

### DIFF
--- a/apps/admin/biome.json
+++ b/apps/admin/biome.json
@@ -5,6 +5,11 @@
     "../../configs/biome/react.json"
   ],
   "linter": {
+    "rules": {
+      "security": {
+        "noDangerouslySetInnerHtml": "off"
+      }
+    },
     "ignore": ["src/routeTree.gen.ts", "src/apis"]
   }
 }

--- a/apps/admin/biome.json
+++ b/apps/admin/biome.json
@@ -5,11 +5,6 @@
     "../../configs/biome/react.json"
   ],
   "linter": {
-    "rules": {
-      "security": {
-        "noDangerouslySetInnerHtml": "off"
-      }
-    },
     "ignore": ["src/routeTree.gen.ts", "src/apis"]
   }
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query-devtools": "^5.62.7",
     "@tanstack/react-router": "^1.104.1",
     "antd": "^5.24.1",
+    "dompurify": "^3.2.5",
     "ky": "^1.7.5",
     "lucide-react": "^0.462.0",
     "react": "catalog:react19",

--- a/apps/admin/src/apis/admin/requests/types.gen.ts
+++ b/apps/admin/src/apis/admin/requests/types.gen.ts
@@ -63,7 +63,7 @@ export type PostCreateRequest = {
   /**
    * 게시글 고정 여부
    */
-  isPinned: boolean;
+  isPinned: string;
 };
 
 /**
@@ -213,7 +213,7 @@ export type PostUpdateRequest = {
   /**
    * 게시글 고정 여부
    */
-  isPinned: boolean;
+  isPinned: string;
 };
 
 /**

--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -22,7 +22,11 @@ const items: MenuItem[] = [
   //TODO: Link 내부 url 변경
   {
     key: 'user',
-    label: <Link to={PATH.USER}>사용자 관리</Link>,
+    label: (
+      <Link to={PATH.USER} search={{ page: 0, query: '' }}>
+        사용자 관리
+      </Link>
+    ),
     icon: <Users size={20} />,
   },
   {
@@ -50,8 +54,22 @@ const items: MenuItem[] = [
     label: '게시판',
     icon: <Clipboard size={20} />,
     children: [
-      { key: 'notice', label: <Link to={PATH.NOTICE}>공지사항</Link> },
-      { key: 'news', label: <Link to={PATH.NEWS}>학부 소식</Link> },
+      {
+        key: 'notice',
+        label: (
+          <Link to={PATH.NOTICE} search={{ page: 0, query: '' }}>
+            공지사항
+          </Link>
+        ),
+      },
+      {
+        key: 'news',
+        label: (
+          <Link to={PATH.NEWS} search={{ page: 0, query: '' }}>
+            학부 소식
+          </Link>
+        ),
+      },
     ],
   },
 ];

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -13,7 +13,7 @@ import {
 import { usePostServicePatchApiV1PostsByPostIdDelete } from '~/apis/admin/queries';
 import { usePostServiceGetApiV1PostsKey } from '~/apis/community/queries';
 
-import { EDIT_POST_PATH_MAP, PATH, type PostCategory } from '~/constants/path';
+import { EDIT_POST_PATH_MAP, type PostCategory } from '~/constants/path';
 import useModal from '~/hooks/use-modal';
 import { queryClient } from '~/utils/get-query-client';
 import { extractFileName } from '~/utils/utils';

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -1,5 +1,6 @@
 import { Link, useRouter } from '@tanstack/react-router';
 import { Button, Modal, message } from 'antd';
+import DOMPurify from 'dompurify';
 import {
   ArrowLeft,
   Calendar,
@@ -63,7 +64,13 @@ function Header({ title, author, views, createdAt, file }: HeaderProps) {
 }
 
 function Content({ content }: { content: string }) {
-  return <div className="px-10 py-8 whitespace-pre-line">{content}</div>;
+  return (
+    <div
+      className="px-10 py-8 whitespace-pre-line"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+    />
+  );
 }
 
 function DeleteButton({ postId }: { postId: number }) {

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -35,12 +35,12 @@ function Board({ children }: { children: React.ReactNode }) {
 
 function Header({ title, author, views, createdAt, file }: HeaderProps) {
   return (
-    <div>
-      <h1 className="font-semibold text-4xl p-8 pb-4">{title}</h1>
-      <div className="flex justify-between border-t border-gray-200 px-8 pt-4 text-gray-500 text-sm">
+    <div className="flex flex-col">
+      <h1 className="p-8 pb-4 text-4xl font-semibold">{title}</h1>
+      <div className="flex justify-between px-8 pt-4 text-sm text-gray-500 border-t border-gray-200">
         <p>{author}</p>
         <div className="flex items-center gap-6">
-          <div className="flex items-center gap-2 sm:visible invisible">
+          <div className="flex items-center invisible gap-2 sm:visible">
             <Eye size={'0.875rem'} />
             <span>{views}</span>
           </div>
@@ -53,7 +53,7 @@ function Header({ title, author, views, createdAt, file }: HeaderProps) {
       {file && (
         <button
           type="button"
-          className="flex items-center self-end px-4 py-2 text-sm font-semibold gap-2"
+          className="flex items-center self-end gap-2 px-4 py-2 mr-4 text-sm font-semibold cursor-pointer"
         >
           <Download size={'0.875rem'} />
           <span>{extractFileName(file.physicalPath)}</span>
@@ -163,8 +163,8 @@ function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
   const editURL = to === PATH.NEWS ? PATH.EDIT_NEWS : PATH.EDIT_NOTICE;
 
   return (
-    <div className="flex flex-col gap-6 items-start">
-      <div className="w-full flex flex-col border-t border-b border-gray-200">
+    <div className="flex flex-col items-start gap-6">
+      <div className="flex flex-col w-full border-t border-b border-gray-200">
         {prevPost ? (
           <Link
             to={`${EDIT_POST_PATH_MAP[to]}`}

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -12,7 +12,7 @@ import {
 import { usePostServicePatchApiV1PostsByPostIdDelete } from '~/apis/admin/queries';
 import { usePostServiceGetApiV1PostsKey } from '~/apis/community/queries';
 
-import { PATH } from '~/constants/path';
+import { EDIT_POST_PATH_MAP, PATH, type PostCategory } from '~/constants/path';
 import useModal from '~/hooks/use-modal';
 import { queryClient } from '~/utils/get-query-client';
 import { extractFileName } from '~/utils/utils';
@@ -148,7 +148,7 @@ interface FooterProps {
     postId: number;
     title: string;
   };
-  to: string;
+  to: PostCategory;
   postId: number;
 }
 
@@ -160,7 +160,8 @@ function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
       <div className="w-full flex flex-col border-t border-b border-gray-200">
         {prevPost ? (
           <Link
-            to={`${to}${prevPost.postId.toString()}`}
+            to={`${EDIT_POST_PATH_MAP[to]}`}
+            params={{ postId: prevPost.postId.toString() }}
             className="flex gap-4 p-5 border-b border-gray-200"
           >
             <span className="font-semibold">이전</span>
@@ -171,7 +172,8 @@ function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
         )}
         {nextPost ? (
           <Link
-            to={`${to}${nextPost.postId.toString()}`}
+            to={`${EDIT_POST_PATH_MAP[to]}`}
+            params={{ postId: prevPost?.postId.toString() }}
             className="flex gap-4 p-5"
           >
             <span className="font-semibold">다음</span>
@@ -185,7 +187,9 @@ function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
       <div className="flex items-center justify-between w-full">
         <Button className="flex items-center gap-2 text-sm">
           <ArrowLeft size={'1rem'} />
-          <Link to={to}>목록으로</Link>
+          <Link to={to} search={{ page: 0, query: '' }}>
+            목록으로
+          </Link>
         </Button>
 
         <div className="flex items-center gap-3">

--- a/apps/admin/src/components/posts/board.tsx
+++ b/apps/admin/src/components/posts/board.tsx
@@ -160,8 +160,6 @@ interface FooterProps {
 }
 
 function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
-  const editURL = to === PATH.NEWS ? PATH.EDIT_NEWS : PATH.EDIT_NOTICE;
-
   return (
     <div className="flex flex-col items-start gap-6">
       <div className="flex flex-col w-full border-t border-b border-gray-200">
@@ -206,7 +204,12 @@ function Footer({ prevPost, nextPost, to, postId }: FooterProps) {
             className="flex items-center gap-2 text-sm"
           >
             <PencilIcon size={'1rem'} />
-            <Link to={`${editURL}${postId.toString()}`}>수정하기</Link>
+            <Link
+              to={EDIT_POST_PATH_MAP[to]}
+              params={{ postId: postId.toString() }}
+            >
+              수정하기
+            </Link>
           </Button>
           <DeleteButton postId={postId} />
         </div>

--- a/apps/admin/src/components/posts/edit-post-field.tsx
+++ b/apps/admin/src/components/posts/edit-post-field.tsx
@@ -73,11 +73,10 @@ function BottomButtons() {
         variant="outlined"
         size="large"
         onClick={openModal}
-        className="self-end"
       >
         취소하기
       </Button>
-      <Button color="primary" variant="solid" size="large" className="self-end">
+      <Button htmlType="submit" color="primary" variant="solid" size="large">
         저장하기
       </Button>
     </div>
@@ -85,6 +84,7 @@ function BottomButtons() {
 }
 
 function EditPostField({ post }: { post?: PostDetailResponse }) {
+  const router = useRouter();
   const [messageApi, contextHolder] = message.useMessage();
   const [form] = Form.useForm();
   const fileUploadMutation = useFileServicePostApiV1FilesPost();
@@ -115,15 +115,16 @@ function EditPostField({ post }: { post?: PostDetailResponse }) {
     reader.readAsDataURL(file);
   };
 
-  const handleSuccess = () => {
+  const handleSuccess = async () => {
     queryClient.invalidateQueries({
       queryKey: [usePostServiceGetApiV1PostsKey],
     });
-
-    messageApi.open({
+    await messageApi.open({
       type: 'success',
       content: '게시글이 성공적으로 수정되었습니다.',
+      duration: 0.7,
     });
+    router.history.back();
   };
 
   const handleError = () => {
@@ -158,7 +159,7 @@ function EditPostField({ post }: { post?: PostDetailResponse }) {
           requestBody: {
             title: values.title,
             category: values.category,
-            isPinned: values.isPinned,
+            isPinned: values.isPinned ? 'TRUE' : 'FALSE',
             fileId,
             content: values.content,
           },
@@ -183,9 +184,6 @@ function EditPostField({ post }: { post?: PostDetailResponse }) {
       <Form
         form={form}
         initialValues={initialValues}
-        onValuesChange={(value) => {
-          console.log(value);
-        }}
         onFinish={handleSubmit}
         className="flex flex-col gap-5"
       >

--- a/apps/admin/src/components/posts/posts-list.tsx
+++ b/apps/admin/src/components/posts/posts-list.tsx
@@ -7,11 +7,16 @@ import {
   type PaginationProps,
   message,
 } from 'antd';
-import { Pin, Trash2Icon } from 'lucide-react';
+import { Pin, PlusIcon, Trash2Icon } from 'lucide-react';
 
 import { usePostServicePatchApiV1PostsByPostIdDelete as useDeletePost } from '~/apis/admin/queries';
 import { usePostServiceGetApiV1PostsKey } from '~/apis/community/queries';
 import type { PostSummaryResponse } from '~/apis/community/requests';
+import {
+  NEW_POST_PATH_MAP,
+  POST_DETAIL_PATH_MAP,
+  type PostCategory,
+} from '~/constants/path';
 
 import useModal from '~/hooks/use-modal';
 import { queryClient } from '~/utils/get-query-client';
@@ -84,14 +89,15 @@ function DeleteButton({ postId, title }: { postId: number; title: string }) {
 
 interface PostListItemProps {
   post: PostSummaryResponse;
-  to: string;
+  to: PostCategory;
 }
 
 function PostListItem({ post, to }: PostListItemProps) {
   return (
     <List.Item className="flex items-center gap-3 transition-colors duration-100 hover:bg-gray-50">
       <Link
-        to={`${to}${post.postId.toString()}`}
+        to={`${POST_DETAIL_PATH_MAP[to]}`}
+        params={{ postId: post.postId.toString() }}
         className="flex justify-between w-full p-1"
       >
         <div className="flex items-center">
@@ -111,14 +117,14 @@ function PostListItem({ post, to }: PostListItemProps) {
 
 interface PostListProps {
   title: string;
-  to: string;
+  to: PostCategory;
   currentPage: number;
   data: PostSummaryResponse[];
   total: number;
 }
 
 function PostsList({ title, to, currentPage, data, total }: PostListProps) {
-  const navigate = useNavigate({ from: '/notice' });
+  const navigate = useNavigate({ from: to });
 
   const handlePageChange: PaginationProps['onChange'] = (currentPage) => {
     navigate({
@@ -129,7 +135,21 @@ function PostsList({ title, to, currentPage, data, total }: PostListProps) {
   return (
     <>
       <List
-        header={<div className="text-lg font-semibold">{title}</div>}
+        header={
+          <div className="flex items-center justify-between p-2">
+            <div className="text-lg font-semibold">{title}</div>
+            <Link to={NEW_POST_PATH_MAP[to]}>
+              <Button
+                color="primary"
+                variant="solid"
+                icon={<PlusIcon size={'1rem'} />}
+                className="flex items-center gap-1"
+              >
+                작성하기
+              </Button>
+            </Link>
+          </div>
+        }
         itemLayout="horizontal"
         bordered
         size="large"

--- a/apps/admin/src/components/posts/write-new-post-field.tsx
+++ b/apps/admin/src/components/posts/write-new-post-field.tsx
@@ -1,0 +1,230 @@
+import { useRouter } from '@tanstack/react-router';
+import {
+  Button,
+  Checkbox,
+  Form,
+  Input,
+  Modal,
+  Radio,
+  Upload,
+  message,
+} from 'antd';
+import type { UploadChangeParam } from 'antd/es/upload';
+import { UploadIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { Editor } from '@aics-client/tiptap';
+
+import {
+  useFileServicePostApiV1FilesPost,
+  usePostServicePatchApiV1PostsByPostId,
+  usePostServicePostApiV1Posts,
+} from '~/apis/admin/queries';
+import type { PostUpdateRequest } from '~/apis/admin/requests';
+import type { PostDetailResponse } from '~/apis/community/requests';
+
+import useModal from '~/hooks/use-modal';
+
+import { usePostServiceGetApiV1PostsKey } from '~/apis/community/queries';
+import { queryClient } from '~/utils/get-query-client';
+import { convertCategory, extractFileName } from '~/utils/utils';
+
+function FormItemWrapper({
+  label,
+  children,
+}: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xl font-semibold">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function BottomButtons() {
+  const { isOpen, openModal, closeModal } = useModal();
+  const router = useRouter();
+
+  return (
+    <div className="flex items-center self-end gap-3">
+      <Modal
+        open={isOpen}
+        onCancel={closeModal}
+        title="게시글 작성 취소"
+        footer={
+          <>
+            <Button
+              color="primary"
+              variant="solid"
+              onClick={() => router.history.back()}
+            >
+              돌아가기
+            </Button>
+            <Button color="default" variant="outlined" onClick={closeModal}>
+              계속 작성하기
+            </Button>
+          </>
+        }
+        width={500}
+      >
+        게시글 작성을 취소하시겠습니까? 작성 중인 내용은 저장되지 않습니다.
+      </Modal>
+      <Button
+        color="default"
+        variant="outlined"
+        size="large"
+        onClick={openModal}
+      >
+        취소하기
+      </Button>
+      <Button htmlType="submit" color="primary" variant="solid" size="large">
+        저장하기
+      </Button>
+    </div>
+  );
+}
+
+function WriteNewPostField() {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage();
+  const [form] = Form.useForm();
+  const fileUploadMutation = useFileServicePostApiV1FilesPost();
+  const postsMutation = usePostServicePostApiV1Posts();
+
+  const handleFileUpload = (file: File) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+  };
+
+  const handleSuccess = async () => {
+    queryClient.invalidateQueries({
+      queryKey: [usePostServiceGetApiV1PostsKey],
+    });
+    await messageApi.open({
+      type: 'success',
+      content: '게시글이 성공적으로 등록되었습니다.',
+      duration: 0.7,
+    });
+    router.history.back();
+  };
+
+  const handleError = () => {
+    messageApi.open({
+      type: 'error',
+      content: '게시글 등록에 실패했습니다.',
+    });
+  };
+
+  const handleSubmit = async (values: PostUpdateRequest) => {
+    try {
+      const fileList = form.getFieldValue('file');
+
+      let fileId: number | undefined = undefined;
+
+      if (fileList && fileList.length > 0) {
+        const originFileObj = fileList[0]?.originFileObj;
+
+        if (originFileObj instanceof File) {
+          const uploadRes = await fileUploadMutation.mutateAsync({
+            formData: { file: originFileObj },
+          });
+          fileId = uploadRes.id;
+        } else if (originFileObj?.id) {
+          fileId = originFileObj.id;
+        }
+      }
+
+      postsMutation.mutate(
+        {
+          fileId: fileId,
+          requestBody: {
+            title: values.title,
+            category: values.category,
+            isPinned: values.isPinned ? 'TRUE' : 'FALSE',
+            content: values.content,
+          },
+        },
+        {
+          onSuccess: () => {
+            handleSuccess();
+          },
+          onError: () => {
+            handleError();
+          },
+        },
+      );
+    } catch (_error) {
+      handleError();
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Form form={form} onFinish={handleSubmit} className="flex flex-col gap-5">
+        <FormItemWrapper label="제목">
+          <Form.Item
+            name="title"
+            rules={[{ required: true, message: '제목을 입력하세요' }]}
+          >
+            <Input placeholder="제목을 입력하세요" size="large" />
+          </Form.Item>
+        </FormItemWrapper>
+
+        <FormItemWrapper label="카테고리">
+          <Form.Item
+            name="category"
+            rules={[{ required: true, message: '카테고리를 선택하세요' }]}
+          >
+            <Radio.Group>
+              <Radio value="NOTIFICATION">공지사항</Radio>
+              <Radio value="NEWS">학부소식</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </FormItemWrapper>
+
+        <FormItemWrapper label="게시글 고정">
+          <Form.Item name="isPinned" valuePropName="checked">
+            <Checkbox>게시글 고정하기</Checkbox>
+          </Form.Item>
+        </FormItemWrapper>
+
+        <FormItemWrapper label="첨부파일">
+          <Form.Item
+            name="file"
+            valuePropName="fileList"
+            getValueFromEvent={(e: UploadChangeParam) =>
+              Array.isArray(e) ? e : e?.fileList
+            }
+          >
+            <Upload
+              beforeUpload={(file) => {
+                handleFileUpload(file);
+                return false;
+              }}
+              maxCount={1}
+            >
+              <Button className="flex items-center">
+                <UploadIcon size={'1rem'} />
+                파일 업로드
+              </Button>
+            </Upload>
+          </Form.Item>
+        </FormItemWrapper>
+
+        <FormItemWrapper label="본문">
+          <Form.Item name="content">
+            <Editor
+              editorContent={''}
+              onChange={(value) => form.setFieldsValue({ content: value })}
+            />
+          </Form.Item>
+        </FormItemWrapper>
+
+        <BottomButtons />
+      </Form>
+    </>
+  );
+}
+
+export { WriteNewPostField };

--- a/apps/admin/src/components/posts/write-new-post-field.tsx
+++ b/apps/admin/src/components/posts/write-new-post-field.tsx
@@ -17,17 +17,14 @@ import { Editor } from '@aics-client/tiptap';
 
 import {
   useFileServicePostApiV1FilesPost,
-  usePostServicePatchApiV1PostsByPostId,
   usePostServicePostApiV1Posts,
 } from '~/apis/admin/queries';
 import type { PostUpdateRequest } from '~/apis/admin/requests';
-import type { PostDetailResponse } from '~/apis/community/requests';
 
 import useModal from '~/hooks/use-modal';
 
 import { usePostServiceGetApiV1PostsKey } from '~/apis/community/queries';
 import { queryClient } from '~/utils/get-query-client';
-import { convertCategory, extractFileName } from '~/utils/utils';
 
 function FormItemWrapper({
   label,

--- a/apps/admin/src/constants/path.ts
+++ b/apps/admin/src/constants/path.ts
@@ -7,7 +7,7 @@ export const PATH = {
   EDIT_NEWS: '/news/edit/',
   EDIT_NOTICE: '/notice/edit/',
   USER: '/user',
-};
+} as const;
 
 export type PostCategory = '/notice' | '/news';
 

--- a/apps/admin/src/constants/path.ts
+++ b/apps/admin/src/constants/path.ts
@@ -1,10 +1,27 @@
 export const PATH = {
   SIGNIN: '/',
   MAIN: '/main',
-  NEWS: '/news/',
-  NOTICE: '/notice/',
+  NEWS: '/news',
+  NOTICE: '/notice',
   CLUB: '/club',
   EDIT_NEWS: '/news/edit/',
   EDIT_NOTICE: '/notice/edit/',
   USER: '/user',
+};
+
+export type PostCategory = '/notice' | '/news';
+
+export const NEW_POST_PATH_MAP: Record<PostCategory, string> = {
+  '/notice': `${PATH.NOTICE}/new`,
+  '/news': `${PATH.NEWS}/new`,
+};
+
+export const POST_DETAIL_PATH_MAP: Record<PostCategory, string> = {
+  '/notice': `${PATH.NOTICE}/$postId`,
+  '/news': `${PATH.NEWS}/$postId`,
+};
+
+export const EDIT_POST_PATH_MAP: Record<PostCategory, string> = {
+  '/notice': `${PATH.EDIT_NOTICE}$postId`,
+  '/news': `${PATH.EDIT_NEWS}$postId`,
 };

--- a/apps/admin/src/routes/news/new/index.tsx
+++ b/apps/admin/src/routes/news/new/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { WriteNewPostField } from '~/components/posts/write-new-post-field';
+
+export const Route = createFileRoute('/news/new/')({
+  component: NewPostPage,
+});
+
+function NewPostPage() {
+  return <WriteNewPostField />;
+}

--- a/apps/admin/src/routes/notice/new/index.tsx
+++ b/apps/admin/src/routes/notice/new/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { WriteNewPostField } from '~/components/posts/write-new-post-field';
+
+export const Route = createFileRoute('/notice/new/')({
+  component: NoticePostPage,
+});
+
+function NoticePostPage() {
+  return <WriteNewPostField />;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       antd:
         specifier: ^5.24.1
         version: 5.24.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      dompurify:
+        specifier: ^3.2.5
+        version: 3.2.5
       ky:
         specifier: ^1.7.5
         version: 1.7.5
@@ -1984,6 +1987,9 @@ packages:
   '@types/tinycolor2@1.4.6':
     resolution: {integrity: sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -2605,6 +2611,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.2.5:
+    resolution: {integrity: sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==}
 
   dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
@@ -6379,6 +6388,9 @@ snapshots:
 
   '@types/tinycolor2@1.4.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@9.0.8': {}
@@ -7203,6 +7215,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.2.5:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-case@2.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

> resolved #92 

게시글 작성 페이지를 추가하였습니다.

## Tasks

- 게시물 작성 페이지 추가
    - 기존 `edit-post-field` 컴포넌트를 재활용하고 싶었으나, 초기값 설정과 파일 업로드 로직 등에서 "생성"과 "수정" 사이에 많은 차이가 있었어요. 이를 하나로 합치게 되면 조건 분기가 많아지고 안정성이 떨어질 것 같아 `write-new-post-field` 컴포넌트를 추가하였어요.
- Link 관련 리팩토링
    - `to={${to}${nextPost.postId.toString()}}`에서 `params={{ postId: prevPost?.postId.toString()}}`를 통해 파라미터를 관리하므로써 tanstack-router에 적합하도록 변경하였어요 .
    - `EDIT_POST_MAP`등의 매핑을 통해 post 쪽의 경로를 관리하였어요.  
    

## To Reviewer

혹시 `write-new-post-field` 컴포넌트를 이대로 두어도 괜찮을 지 이야기를 나누고 싶어요! 


## Screenshot

>게시물 수정과 동일한 UI

![image](https://github.com/user-attachments/assets/d578b709-cf30-4fdd-b470-c0f0f92a2c18)

