### PR TITLE
feat(tiptap): tiptap 에디터 이미지 다중 첨부 기능 추가

### DIFF
--- a/packages/tiptap/src/components/editor/editor.tsx
+++ b/packages/tiptap/src/components/editor/editor.tsx
@@ -74,7 +74,7 @@ export default function Editor({ editorContent, onChange }: EditorProps) {
   }
 
   return (
-    <div className="w-full border border-gray-300 overflow-hidden rounded-lg">
+    <div className="w-full border border-gray-300 rounded-lg">
       <MenuBar editor={editor} />
       <EditorContent editor={editor} />
     </div>

--- a/packages/tiptap/src/components/editor/editor.tsx
+++ b/packages/tiptap/src/components/editor/editor.tsx
@@ -74,7 +74,7 @@ export default function Editor({ editorContent, onChange }: EditorProps) {
   }
 
   return (
-    <div className="w-full border border-gray-300 rounded-lg">
+    <div className="w-full border border-gray-300 overflow-hidden rounded-lg">
       <MenuBar editor={editor} />
       <EditorContent editor={editor} />
     </div>

--- a/packages/tiptap/src/components/menu-bar/menu-bar.tsx
+++ b/packages/tiptap/src/components/menu-bar/menu-bar.tsx
@@ -45,10 +45,18 @@ export default function MenuBar({ editor }: { editor: Editor }) {
 
     try {
       for (const file of Array.from(files)) {
+        if (!file.type.startsWith('image/')) {
+          alert('이미지 파일만 업로드할 수 있습니다');
+          continue;
+        }
+
         const base64 = await new Promise<string>((resolve, reject) => {
           const reader = new FileReader();
           reader.onload = () => resolve(reader.result as string);
-          reader.onerror = () => reject(new Error('이미지 업로드 실패'));
+          reader.onerror = () => {
+            alert('이미지 업로드 중 오류가 발생했습니다.');
+            reject(new Error('이미지 업로드 실패'));
+          };
           reader.readAsDataURL(file);
         });
 

--- a/packages/tiptap/src/components/menu-bar/menu-bar.tsx
+++ b/packages/tiptap/src/components/menu-bar/menu-bar.tsx
@@ -22,7 +22,7 @@ import { MenuButton } from './menu-button.tsx';
 
 function MenuBarWrapper({ children }: { children: ReactNode }) {
   return (
-    <div className="flex items-center justify-start py-3 border-b border-gray-300">
+    <div className="flex items-center justify-start py-3 w-full overflow-x-auto border-b border-gray-300">
       {children}
     </div>
   );

--- a/packages/tiptap/src/components/menu-bar/menu-bar.tsx
+++ b/packages/tiptap/src/components/menu-bar/menu-bar.tsx
@@ -40,20 +40,24 @@ export default function MenuBar({ editor }: { editor: Editor }) {
   const handleImageUpload = async (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
 
     try {
-      const base64 = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error('업로드에 실패하였습니다.'));
-        reader.readAsDataURL(file);
-      });
+      for (const file of Array.from(files)) {
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => reject(new Error('이미지 업로드 실패'));
+          reader.readAsDataURL(file);
+        });
 
-      editor.chain().focus().setImage({ src: base64 }).run();
+        editor.chain().focus().setImage({ src: base64 }).run();
+      }
     } catch (e) {
       console.error(e);
+    } finally {
+      event.target.value = '';
     }
   };
 
@@ -173,6 +177,7 @@ export default function MenuBar({ editor }: { editor: Editor }) {
         <input
           type="file"
           accept="image/*"
+          multiple
           id="image-upload"
           className="size-0"
           onChange={handleImageUpload}

--- a/packages/tiptap/src/utils/custom-extensions.ts
+++ b/packages/tiptap/src/utils/custom-extensions.ts
@@ -65,6 +65,7 @@ const CustomTextAlignConfigure = TextAlign.configure({
 
 const CustomImageConfigure = Image.configure({
   allowBase64: true,
+  inline: true,
 });
 
 const CustomLinkConfigure = Link.configure({


### PR DESCRIPTION
## Summary

> resolved #107 

tiptap 에디터에 이미지 다중 첨부 기능을 추가하였어요.

## Tasks

- tiptap 이미지 다중 첨부 기능 추가
- 반응형 개선
    - 인프런의 커뮤니티에서 사용한 tiptap 에디터를 참고하여, 화면의 크기에 따라 기능이 사라지거나 overflow시 메뉴바만이 scrollable 하도록 처리하였어요.
    - > ref) 인프런 커뮤니티
     ![image](https://github.com/user-attachments/assets/2764feef-46d5-4364-967d-3fd12e8c5c09)
 


## Screenshot

![image](https://github.com/user-attachments/assets/f9d8f848-adba-4df8-ab68-f3d886d50f71)
