### PR TITLE
feat(admin): 학부 소개 및 찾아오시는 길 관리 페이지 추가

### DIFF
--- a/apps/admin/src/apis/admin/queries/queries.ts
+++ b/apps/admin/src/apis/admin/queries/queries.ts
@@ -666,7 +666,7 @@ export const useCarouselServicePatchApiV1CarouselsById = <
       }) as unknown as Promise<TData>,
     ...options,
   });
-export const useAboutServicePatchApiV1AboutsById = <
+export const useAboutServicePatchApiV1Abouts = <
   TData = Common.AboutServicePatchApiV1AboutsByIdMutationResult,
   TError = unknown,
   TContext = unknown,
@@ -676,7 +676,7 @@ export const useAboutServicePatchApiV1AboutsById = <
       TData,
       TError,
       {
-        id: number;
+        category: 'DEPT_INTRO' | 'DIRECTIONS';
         requestBody: AboutUpdateRequest;
       },
       TContext
@@ -688,14 +688,14 @@ export const useAboutServicePatchApiV1AboutsById = <
     TData,
     TError,
     {
-      id: number;
+      category: 'DEPT_INTRO' | 'DIRECTIONS';
       requestBody: AboutUpdateRequest;
     },
     TContext
   >({
-    mutationFn: ({ id, requestBody }) =>
+    mutationFn: ({ category, requestBody }) =>
       AboutService.patchApiV1AboutsById({
-        id,
+        category,
         requestBody,
       }) as unknown as Promise<TData>,
     ...options,

--- a/apps/admin/src/apis/admin/requests/services.gen.ts
+++ b/apps/admin/src/apis/admin/requests/services.gen.ts
@@ -628,7 +628,7 @@ export class AboutService {
    * - Assignee : 이신행
    *
    * @param data The data for the request.
-   * @param data.id 소개글 ID는 URL 경로 변수 입니다.
+   * @param data.category 카테고리는 ENUM 타입입니다.
    * @param data.requestBody
    * @returns void No Content
    * @throws ApiError
@@ -638,9 +638,9 @@ export class AboutService {
   ): CancelablePromise<PatchApiV1AboutsByIdResponse> {
     return __request(OpenAPI, {
       method: 'PATCH',
-      url: '/api/v1/abouts/{id}',
-      path: {
-        id: data.id,
+      url: '/api/v1/abouts',
+      query: {
+        category: data.category,
       },
       body: data.requestBody,
       mediaType: 'application/json',

--- a/apps/admin/src/apis/admin/requests/types.gen.ts
+++ b/apps/admin/src/apis/admin/requests/types.gen.ts
@@ -601,7 +601,7 @@ export type PatchApiV1AboutsByIdData = {
   /**
    * 소개글 ID는 URL 경로 변수 입니다.
    */
-  id: number;
+  category: 'DEPT_INTRO' | 'DIRECTIONS';
   requestBody: AboutUpdateRequest;
 };
 

--- a/apps/admin/src/components/aside-navigation-menu.tsx
+++ b/apps/admin/src/components/aside-navigation-menu.tsx
@@ -19,7 +19,6 @@ import { formatExpireTime } from '~/utils/utils';
 type MenuItem = Required<MenuProps>['items'][number];
 
 const items: MenuItem[] = [
-  //TODO: Link 내부 url 변경
   {
     key: 'user',
     label: (
@@ -34,19 +33,22 @@ const items: MenuItem[] = [
     label: '소개',
     icon: <GraduationCap size={20} />,
     children: [
-      { key: 'dept', label: <Link to="/">학부 소개</Link> },
+      { key: 'dept', label: <Link to={PATH.DEPT}>학부 소개</Link> },
       { key: 'club', label: <Link to={PATH.CLUB}>동아리 소개</Link> },
-      { key: 'contact', label: <Link to="/">찾아오시는 길</Link> },
+      {
+        key: 'contact',
+        label: <Link to={PATH.DIRECTIONS}>찾아오시는 길</Link>,
+      },
     ],
   },
   {
     key: 'professor',
-    label: <Link to="/professor">교수진 소개</Link>,
+    label: <Link to={PATH.PROFESSOR}>교수진 소개</Link>,
     icon: <Speech size={20} />,
   },
   {
     key: 'lab',
-    label: <Link to="/lab">연구실 소개</Link>,
+    label: <Link to={PATH.LAB}>연구실 소개</Link>,
     icon: <FlaskConical size={20} />,
   },
   {

--- a/apps/admin/src/constants/path.ts
+++ b/apps/admin/src/constants/path.ts
@@ -1,6 +1,12 @@
 export const PATH = {
   SIGNIN: '/',
   MAIN: '/main',
+  DEPT: '/dept',
+  EDIT_DEPT: '/dept/edit',
+  DIRECTIONS: '/directions',
+  EDIT_DIRECTIONS: '/directions/edit',
+  LAB: '/lab',
+  PROFESSOR: '/professor',
   NEWS: '/news',
   NOTICE: '/notice',
   CLUB: '/club',

--- a/apps/admin/src/routes/dept/edit/index.tsx
+++ b/apps/admin/src/routes/dept/edit/index.tsx
@@ -1,0 +1,102 @@
+import { Editor } from '@aics-client/tiptap';
+import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { Button, message } from 'antd';
+import { useState } from 'react';
+import { useAboutServicePostApiV1Abouts } from '~/apis/admin/queries';
+import { useAboutServicePatchApiV1Abouts } from '~/apis/admin/queries';
+import { UseAboutServiceGetApiV1AboutsKeyFn } from '~/apis/community/queries';
+import { useAboutServiceGetApiV1AboutsSuspense } from '~/apis/community/queries/suspense';
+import { queryClient } from '~/utils/get-query-client';
+
+export const Route = createFileRoute('/dept/edit/')({
+  component: DeptEditPage,
+});
+
+const CATEGORY = 'DEPT_INTRO';
+
+function DeptEditPage() {
+  const [messageApi, contextHolder] = message.useMessage();
+  const router = useRouter();
+  const { data } = useAboutServiceGetApiV1AboutsSuspense({
+    category: CATEGORY,
+  });
+  const isContentEmpty = data.content === null;
+  const [content, setContent] = useState(data.content);
+  const { mutate: postDeptIntro } = useAboutServicePostApiV1Abouts();
+  const { mutate: patchDeptIntro } = useAboutServicePatchApiV1Abouts();
+
+  const handleSuccess = async () => {
+    queryClient.invalidateQueries({
+      queryKey: UseAboutServiceGetApiV1AboutsKeyFn({ category: CATEGORY }),
+    });
+    await messageApi.open({
+      type: 'success',
+      content: '소개글이 성공적으로 저장되었습니다.',
+      duration: 0.7,
+    });
+    router.history.back();
+  };
+
+  const handleError = () => {
+    messageApi.open({
+      type: 'error',
+      content: '소개글을 저장하는 도중 오류가 발생했습니다.',
+    });
+  };
+
+  const handlePostDeptIntro = () => {
+    postDeptIntro(
+      { requestBody: { category: CATEGORY, content } },
+      {
+        onSuccess: () => {
+          handleSuccess();
+        },
+        onError: () => {
+          handleError();
+        },
+      },
+    );
+  };
+
+  const handlePatchDeptIntro = () => {
+    patchDeptIntro(
+      { category: CATEGORY, requestBody: { content } },
+      {
+        onSuccess: () => {
+          handleSuccess();
+        },
+        onError: () => {
+          handleError();
+        },
+      },
+    );
+  };
+
+  const handleSave = () => {
+    if (isContentEmpty) {
+      handlePostDeptIntro();
+    } else {
+      handlePatchDeptIntro();
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <section className="flex flex-col w-full gap-8">
+        <h1 className="text-3xl font-bold">학부 소개</h1>
+        <section className="border-y py-8 border-gray-200">
+          <Editor
+            editorContent={content}
+            onChange={(newContent) => setContent(newContent)}
+          />
+        </section>
+        <Button type="primary" className="self-end" onClick={handleSave}>
+          저장하기
+        </Button>
+      </section>
+    </>
+  );
+}
+
+export default DeptEditPage;

--- a/apps/admin/src/routes/dept/index.tsx
+++ b/apps/admin/src/routes/dept/index.tsx
@@ -1,0 +1,47 @@
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { Button } from 'antd';
+import DOMPurify from 'dompurify';
+
+import { useAboutServiceGetApiV1AboutsSuspense } from '~/apis/community/queries/suspense';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/dept/')({
+  component: DeptPage,
+});
+
+const CATEGORY = 'DEPT_INTRO';
+
+function DeptPage() {
+  const { data } = useAboutServiceGetApiV1AboutsSuspense({
+    category: CATEGORY,
+  });
+
+  const isDeptIntroEmpty = data.content === '' || data.content === '<p></p>';
+
+  return (
+    <section className="flex flex-col w-full gap-8">
+      <h1 className="text-3xl font-bold ">학부 소개</h1>
+      {isDeptIntroEmpty ? (
+        <span className="border-y py-8 border-gray-200">
+          작성된 학부 소개가 없습니다.
+        </span>
+      ) : (
+        <section
+          className="border-y py-8 border-gray-200 flex flex-col gap-4"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.content) }}
+        />
+      )}
+
+      <Link to={PATH.EDIT_DEPT} className="self-end">
+        {isDeptIntroEmpty ? (
+          <Button type="primary">작성하기</Button>
+        ) : (
+          <Button type="primary">수정하기</Button>
+        )}
+      </Link>
+    </section>
+  );
+}
+
+export default DeptPage;

--- a/apps/admin/src/routes/dept/index.tsx
+++ b/apps/admin/src/routes/dept/index.tsx
@@ -20,7 +20,16 @@ function DeptPage() {
 
   return (
     <section className="flex flex-col w-full gap-8">
-      <h1 className="text-3xl font-bold ">학부 소개</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold ">학부 소개</h1>
+        <Link to={PATH.EDIT_DEPT} className="self-end">
+          {isDeptIntroEmpty ? (
+            <Button type="primary">작성하기</Button>
+          ) : (
+            <Button type="primary">수정하기</Button>
+          )}
+        </Link>
+      </div>
       {isDeptIntroEmpty ? (
         <span className="border-y py-8 border-gray-200">
           작성된 학부 소개가 없습니다.
@@ -32,14 +41,6 @@ function DeptPage() {
           dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.content) }}
         />
       )}
-
-      <Link to={PATH.EDIT_DEPT} className="self-end">
-        {isDeptIntroEmpty ? (
-          <Button type="primary">작성하기</Button>
-        ) : (
-          <Button type="primary">수정하기</Button>
-        )}
-      </Link>
     </section>
   );
 }

--- a/apps/admin/src/routes/directions/edit/index.tsx
+++ b/apps/admin/src/routes/directions/edit/index.tsx
@@ -1,0 +1,102 @@
+import { Editor } from '@aics-client/tiptap';
+import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { Button, message } from 'antd';
+import { useState } from 'react';
+import { useAboutServicePostApiV1Abouts } from '~/apis/admin/queries';
+import { useAboutServicePatchApiV1Abouts } from '~/apis/admin/queries';
+import { UseAboutServiceGetApiV1AboutsKeyFn } from '~/apis/community/queries';
+import { useAboutServiceGetApiV1AboutsSuspense } from '~/apis/community/queries/suspense';
+import { queryClient } from '~/utils/get-query-client';
+
+export const Route = createFileRoute('/directions/edit/')({
+  component: DirectionsEditPage,
+});
+
+const CATEGORY = 'DIRECTIONS';
+
+function DirectionsEditPage() {
+  const [messageApi, contextHolder] = message.useMessage();
+  const router = useRouter();
+  const { data } = useAboutServiceGetApiV1AboutsSuspense({
+    category: CATEGORY,
+  });
+  const isContentEmpty = data.content === null;
+  const [content, setContent] = useState(data.content);
+  const { mutate: postDirections } = useAboutServicePostApiV1Abouts();
+  const { mutate: patchDirections } = useAboutServicePatchApiV1Abouts();
+
+  const handleSuccess = async () => {
+    queryClient.invalidateQueries({
+      queryKey: UseAboutServiceGetApiV1AboutsKeyFn({ category: CATEGORY }),
+    });
+    await messageApi.open({
+      type: 'success',
+      content: '안내문이 성공적으로 저장되었습니다.',
+      duration: 0.7,
+    });
+    router.history.back();
+  };
+
+  const handleError = () => {
+    messageApi.open({
+      type: 'error',
+      content: '안내문을 저장하는 도중 오류가 발생했습니다.',
+    });
+  };
+
+  const handlePostDirections = () => {
+    postDirections(
+      { requestBody: { category: CATEGORY, content } },
+      {
+        onSuccess: () => {
+          handleSuccess();
+        },
+        onError: () => {
+          handleError();
+        },
+      },
+    );
+  };
+
+  const handlePatchDirections = () => {
+    patchDirections(
+      { category: CATEGORY, requestBody: { content } },
+      {
+        onSuccess: () => {
+          handleSuccess();
+        },
+        onError: () => {
+          handleError();
+        },
+      },
+    );
+  };
+
+  const handleSave = () => {
+    if (isContentEmpty) {
+      handlePostDirections();
+    } else {
+      handlePatchDirections();
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <section className="flex flex-col w-full gap-8">
+        <h1 className="text-3xl font-bold">찾아오시는 길</h1>
+        <section className="border-y py-8 border-gray-200">
+          <Editor
+            editorContent={content}
+            onChange={(newContent) => setContent(newContent)}
+          />
+        </section>
+        <Button type="primary" className="self-end" onClick={handleSave}>
+          저장하기
+        </Button>
+      </section>
+    </>
+  );
+}
+
+export default DirectionsEditPage;

--- a/apps/admin/src/routes/directions/index.tsx
+++ b/apps/admin/src/routes/directions/index.tsx
@@ -20,7 +20,16 @@ function DirectionsPage() {
 
   return (
     <section className="flex flex-col w-full gap-8">
-      <h1 className="text-3xl font-bold ">찾아오시는 길</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold ">찾아오시는 길</h1>
+        <Link to={PATH.EDIT_DEPT} className="self-end">
+          {isDirectionsEmpty ? (
+            <Button type="primary">작성하기</Button>
+          ) : (
+            <Button type="primary">수정하기</Button>
+          )}
+        </Link>
+      </div>
       {isDirectionsEmpty ? (
         <span className="border-y py-8 border-gray-200">
           작성된 안내가 없습니다.

--- a/apps/admin/src/routes/directions/index.tsx
+++ b/apps/admin/src/routes/directions/index.tsx
@@ -1,0 +1,47 @@
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { Button } from 'antd';
+import DOMPurify from 'dompurify';
+
+import { useAboutServiceGetApiV1AboutsSuspense } from '~/apis/community/queries/suspense';
+import { PATH } from '~/constants/path';
+
+export const Route = createFileRoute('/directions/')({
+  component: DirectionsPage,
+});
+
+const CATEGORY = 'DIRECTIONS';
+
+function DirectionsPage() {
+  const { data } = useAboutServiceGetApiV1AboutsSuspense({
+    category: CATEGORY,
+  });
+
+  const isDirectionsEmpty = data.content === '' || data.content === '<p></p>';
+
+  return (
+    <section className="flex flex-col w-full gap-8">
+      <h1 className="text-3xl font-bold ">찾아오시는 길</h1>
+      {isDirectionsEmpty ? (
+        <span className="border-y py-8 border-gray-200">
+          작성된 안내가 없습니다.
+        </span>
+      ) : (
+        <section
+          className="border-y py-8 border-gray-200 flex flex-col gap-4"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.content) }}
+        />
+      )}
+
+      <Link to={PATH.EDIT_DIRECTIONS} className="self-end">
+        {isDirectionsEmpty ? (
+          <Button type="primary">작성하기</Button>
+        ) : (
+          <Button type="primary">수정하기</Button>
+        )}
+      </Link>
+    </section>
+  );
+}
+
+export default DirectionsPage;

--- a/apps/admin/src/routes/directions/index.tsx
+++ b/apps/admin/src/routes/directions/index.tsx
@@ -22,7 +22,7 @@ function DirectionsPage() {
     <section className="flex flex-col w-full gap-8">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold ">찾아오시는 길</h1>
-        <Link to={PATH.EDIT_DEPT} className="self-end">
+        <Link to={PATH.EDIT_DIRECTIONS} className="self-end">
           {isDirectionsEmpty ? (
             <Button type="primary">작성하기</Button>
           ) : (
@@ -41,14 +41,6 @@ function DirectionsPage() {
           dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(data.content) }}
         />
       )}
-
-      <Link to={PATH.EDIT_DIRECTIONS} className="self-end">
-        {isDirectionsEmpty ? (
-          <Button type="primary">작성하기</Button>
-        ) : (
-          <Button type="primary">수정하기</Button>
-        )}
-      </Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

> resolved #130 #131 

학부 소개 및 찾아오시는 길을 관리하는 두 페이지를 추가하였습니다.

## Tasks

- 학부 소개 상세 페이지
- 학부 소개 수정 페이지
- 찾아오시는 길 상세 페이지
- 찾아오시는 길 수정 페이지


## To Reviewer

현재 tiptap에서 오류가 발생하여 에디터의 뷰와 게시글의 생김새가 정상적이지 못합니다. 해당 부분은 원인을 찾아 따로 수정할게요!


## Screenshot

>학부 소개 상세 페이지

![image](https://github.com/user-attachments/assets/299eeb3a-f827-463e-9597-f5d214c29986)

>학부 소개 수정 페이지

![image](https://github.com/user-attachments/assets/af285eac-871e-4f91-b205-36e6736286d7)

>찾아오시는 길 상세 페이지

![image](https://github.com/user-attachments/assets/01fa478a-c105-4103-9f0d-7bc67bf4ae43)

>찾아오시는 길 수정 페이지

![image](https://github.com/user-attachments/assets/1ce15254-76fd-42d9-bd3c-660dc1897914)
