### PR TITLE
refactor(community): 게시글에 dompurify 적용

### DIFF
--- a/apps/community/package.json
+++ b/apps/community/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query-devtools": "^5.72.1",
     "@vanilla-extract/css": "^1.17.1",
     "babel-plugin-react-compiler": "19.0.0-beta-e993439-20250405",
+    "dompurify": "^3.2.5",
     "embla-carousel": "^8.6.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",

--- a/apps/community/src/app/page.tsx
+++ b/apps/community/src/app/page.tsx
@@ -1,7 +1,7 @@
 import * as styles from '~/app/page.css';
 import { HeroCarousel } from '~/components/main/hero-carousel';
-import { NewsCarousel } from '~/components/main/news-carousel';
-import { NoticeList } from '~/components/main/notice-list';
+import NewsCarousel from '~/components/main/news-carousel.client';
+import NoticeList from '~/components/main/notice-list.client';
 
 export default async function Home() {
   return (

--- a/apps/community/src/components/board/board.tsx
+++ b/apps/community/src/components/board/board.tsx
@@ -7,6 +7,7 @@ import {
   Download,
   Eye,
 } from '@aics-client/design-system/icons';
+import DOMPurify from 'dompurify';
 
 import * as styles from '~/components/board/board.css';
 
@@ -53,7 +54,13 @@ function Header({ title, author, views, createdAt, file }: HeaderProps) {
 }
 
 function Content({ content }: { content: string }) {
-  return <div className={styles.content}>{content}</div>;
+  return (
+    <div
+      className={styles.content}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+    />
+  );
 }
 
 interface FooterProps {

--- a/apps/community/src/components/main/news-carousel.client.tsx
+++ b/apps/community/src/components/main/news-carousel.client.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// 클라이언트 전용 dynamic import
+const NewsCarousel = dynamic(() => import('./news-carousel'), {
+  ssr: false,
+});
+
+export default NewsCarousel;

--- a/apps/community/src/components/main/news-carousel.client.tsx
+++ b/apps/community/src/components/main/news-carousel.client.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from 'next/dynamic';
 
-// 클라이언트 전용 dynamic import
 const NewsCarousel = dynamic(() => import('./news-carousel'), {
   ssr: false,
 });

--- a/apps/community/src/components/main/news-carousel.tsx
+++ b/apps/community/src/components/main/news-carousel.tsx
@@ -65,4 +65,4 @@ function NewsCarousel() {
   );
 }
 
-export { NewsCarousel };
+export default NewsCarousel;

--- a/apps/community/src/components/main/news-carousel.tsx
+++ b/apps/community/src/components/main/news-carousel.tsx
@@ -5,6 +5,7 @@ import Autoplay from 'embla-carousel-autoplay';
 import useEmblaCarousel from 'embla-carousel-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import DOMPurify from 'dompurify';
 
 import { MAIN_QUERY_OPTIONS } from '~/apis/main/queries';
 import AltImage from '~/assets/images/alt.png';
@@ -40,7 +41,7 @@ function NewsCarousel() {
           {recentNews.map((post) => (
             <Link
               key={`news-${post.postId}`}
-              href={`/board/news/${post.postId}`}
+              href={`/news/${post.postId}`}
               className={styles.link}
             >
               <div className={styles.slide}>
@@ -48,7 +49,13 @@ function NewsCarousel() {
                   <Image src={AltImage} alt="preview-image" fill />
                 </div>
                 <h3 className={styles.slideTitle}>{post.title}</h3>
-                <p className={styles.slideDescription}>{post.description}</p>
+                <p
+                  className={styles.slideDescription}
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(post.description),
+                  }}
+                />
               </div>
             </Link>
           ))}

--- a/apps/community/src/components/main/news-carousel.tsx
+++ b/apps/community/src/components/main/news-carousel.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
 import Autoplay from 'embla-carousel-autoplay';
 import useEmblaCarousel from 'embla-carousel-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import DOMPurify from 'dompurify';
 
 import { MAIN_QUERY_OPTIONS } from '~/apis/main/queries';
 import AltImage from '~/assets/images/alt.png';
@@ -49,7 +49,7 @@ function NewsCarousel() {
                   <Image src={AltImage} alt="preview-image" fill />
                 </div>
                 <h3 className={styles.slideTitle}>{post.title}</h3>
-                <p
+                <div
                   className={styles.slideDescription}
                   // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
                   dangerouslySetInnerHTML={{

--- a/apps/community/src/components/main/notice-list.client.tsx
+++ b/apps/community/src/components/main/notice-list.client.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// 클라이언트 전용 dynamic import
+const NoticeList = dynamic(() => import('./notice-list'), {
+  ssr: false,
+});
+
+export default NoticeList;

--- a/apps/community/src/components/main/notice-list.client.tsx
+++ b/apps/community/src/components/main/notice-list.client.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from 'next/dynamic';
 
-// 클라이언트 전용 dynamic import
 const NoticeList = dynamic(() => import('./notice-list'), {
   ssr: false,
 });

--- a/apps/community/src/components/main/notice-list.tsx
+++ b/apps/community/src/components/main/notice-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
+import DOMPurify from 'dompurify';
 import Link from 'next/link';
 
 import { MAIN_QUERY_OPTIONS } from '~/apis/main/queries';
@@ -23,7 +24,13 @@ function NoticeList() {
           <li key={`notice-${post.postId}`}>
             <Link href={`/board/notice/${post.postId}`} className={styles.post}>
               <h2 className={styles.postTitle}>{post.title}</h2>
-              <p className={styles.postDescription}>{post.description}</p>
+              <div
+                className={styles.postDescription}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify 적용
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(post.description),
+                }}
+              />
             </Link>
           </li>
         ))}
@@ -32,4 +39,4 @@ function NoticeList() {
   );
 }
 
-export { NoticeList };
+export default NoticeList;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-e993439-20250405
         version: 19.0.0-beta-e993439-20250405
+      dompurify:
+        specifier: ^3.2.5
+        version: 3.2.5
       embla-carousel:
         specifier: ^8.6.0
         version: 8.6.0
@@ -197,7 +200,7 @@ importers:
         version: 0.5.5(@vanilla-extract/css@1.17.1)
       '@vanilla-extract/sprinkles':
         specifier: ^1.6.3
-        version: 1.6.3(@vanilla-extract/css@1.16.0)
+        version: 1.6.3(@vanilla-extract/css@1.17.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1815,9 +1818,6 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@20.17.30':
-    resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
-
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
@@ -1852,9 +1852,6 @@ packages:
 
   '@vanilla-extract/compiler@0.1.2':
     resolution: {integrity: sha512-B4T5P+Fz2Big0GRspQSi4BIyPF3cJ2/+/NWSI6Lw5Tq2JXv9nzjTGU4gKlWzyvaxt/0CLPE+Zo40fUsUv5lttQ==}
-
-  '@vanilla-extract/css@1.16.0':
-    resolution: {integrity: sha512-05JTbvG1E0IrSZKZ5el2EM9CmAX0XSdsNY+d4aRZxDvYf3/hwxomvFFEz2b/awjgg9yTVHW83Wq19wE4OoTEMg==}
 
   '@vanilla-extract/css@1.17.1':
     resolution: {integrity: sha512-tOHQXHm10FrJeXKFeWE09JfDGN/tvV6mbjwoNB9k03u930Vg021vTnbrCwVLkECj9Zvh/SHLBHJ4r2flGqfovw==}
@@ -3312,9 +3309,6 @@ packages:
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
-  modern-ahocorasick@1.0.1:
-    resolution: {integrity: sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA==}
-
   modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
@@ -4389,9 +4383,6 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -6071,10 +6062,6 @@ snapshots:
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@20.17.30':
-    dependencies:
-      undici-types: 6.19.8
-
   '@types/node@22.14.0':
     dependencies:
       undici-types: 6.21.0
@@ -6129,23 +6116,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/css@1.16.0':
-    dependencies:
-      '@emotion/hash': 0.9.2
-      '@vanilla-extract/private': 1.0.6
-      css-what: 6.1.0
-      cssesc: 3.0.0
-      csstype: 3.1.3
-      dedent: 1.5.3
-      deep-object-diff: 1.1.9
-      deepmerge: 4.3.1
-      lru-cache: 10.4.3
-      media-query-parser: 2.0.2
-      modern-ahocorasick: 1.0.1
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-
   '@vanilla-extract/css@1.17.1':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -6194,9 +6164,9 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.17.1
 
-  '@vanilla-extract/sprinkles@1.6.3(@vanilla-extract/css@1.16.0)':
+  '@vanilla-extract/sprinkles@1.6.3(@vanilla-extract/css@1.17.1)':
     dependencies:
-      '@vanilla-extract/css': 1.16.0
+      '@vanilla-extract/css': 1.17.1
 
   '@vanilla-extract/vite-plugin@5.0.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3))':
     dependencies:
@@ -7442,7 +7412,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 22.14.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -7706,8 +7676,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
-
-  modern-ahocorasick@1.0.1: {}
 
   modern-ahocorasick@1.1.0: {}
 
@@ -8946,8 +8914,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

> resolved #129 

커뮤니티 게시글에 dompurify를 적용하였어요.


## Tasks

- init dompurify
- 게시글 내부에 dompurify 적용

## To Reviewers

메인 페이지 내부에서 사용되는 `news-carousel`과 `notice-list`에 `dompurify`를 적용하였을 때, `sanitize` 함수를 정의하지 못하는 에러가 발생하였어요. 
`dompurify`는 브라우저 환경에서 동작하는 라이브러리이기 때문에, 서버 환경에서는 제대로 작동하지 않아 발생한 문제였는데요, 이를 해결하기 위해 두 컴포넌트를 `dynamic-import`하여 클라이언트 사이드에서 렌더링 가능하도록 처리하였어요!

혹시 더 좋은 방법이 생각나신다면 리뷰로 달아주세요 !!
