### PR TITLE
feat(admin): 메인페이지 추가

### DIFF
--- a/apps/admin/src/components/hero-images/hero-carousel.tsx
+++ b/apps/admin/src/components/hero-images/hero-carousel.tsx
@@ -12,7 +12,7 @@ function HeroCarousel({ images, autoplay = true }: HeroCarouselProps) {
   return (
     <Carousel
       autoplay={autoplay}
-      className="custom-carousel border border-gray-200 aspect-[16/9] rounded-sm"
+      className="custom-carousel border border-gray-200 aspect-[16/9] rounded-lg"
     >
       {images.map((image) => (
         <div key={image.id} className="rounded-lg">

--- a/apps/admin/src/components/main/posts-list-card.tsx
+++ b/apps/admin/src/components/main/posts-list-card.tsx
@@ -1,0 +1,52 @@
+import { Link } from '@tanstack/react-router';
+import { Card } from 'antd';
+import { ArrowRightIcon } from 'lucide-react';
+
+import type { PostSummaryResponse } from '~/apis/community/requests';
+
+import { POST_DETAIL_PATH_MAP, type PostCategory } from '~/constants/path';
+
+interface PostListCardProps {
+  title: string;
+  to: PostCategory;
+  posts: PostSummaryResponse[];
+}
+
+function PostListCard({ title, to, posts }: PostListCardProps) {
+  return (
+    <Card
+      title={title}
+      extra={
+        <Link to={to} search={{ page: 0, query: '' }}>
+          <button
+            type="button"
+            className="flex gap-1 items-center text-black cursor-pointer"
+          >
+            더보기
+            <ArrowRightIcon size={'1rem'} />
+          </button>
+        </Link>
+      }
+      className="w-full flex flex-col"
+    >
+      {posts?.map((post, index) => {
+        const isLast = index === posts.length - 1;
+        return (
+          <div
+            key={post.postId}
+            className={`py-2  ${isLast ? '' : 'border-b border-gray-200'}`}
+          >
+            <Link
+              to={`${POST_DETAIL_PATH_MAP[to]}`}
+              params={{ postId: post?.postId.toString() }}
+            >
+              <span className="text-black">{post.title}</span>
+            </Link>
+          </div>
+        );
+      })}
+    </Card>
+  );
+}
+
+export { PostListCard };

--- a/apps/admin/src/routes/main/index.tsx
+++ b/apps/admin/src/routes/main/index.tsx
@@ -1,9 +1,50 @@
+import { Suspense } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
+import { Spin } from 'antd';
+
+import {
+  useCarouselServiceGetApiV1CarouselsSuspense,
+  usePostServiceGetApiV1PostsSuspense,
+} from '~/apis/community/queries/suspense';
+
+import { HeroCarousel } from '~/components/hero-images/hero-carousel';
+import { PostListCard } from '~/components/main/posts-list-card';
+import { PATH } from '~/constants/path';
 
 export const Route = createFileRoute('/main/')({
   component: MainPage,
 });
 
 function MainPage() {
-  return <div>main</div>;
+  const { data: carouselImages } =
+    useCarouselServiceGetApiV1CarouselsSuspense();
+  const { data: noticeList } = usePostServiceGetApiV1PostsSuspense({
+    category: 'NOTIFICATION',
+    page: 0,
+    size: 5,
+  });
+  const { data: newsList } = usePostServiceGetApiV1PostsSuspense({
+    category: 'NEWS',
+    page: 0,
+    size: 5,
+  });
+  return (
+    <Suspense fallback={<Spin />}>
+      <section className="flex flex-col gap-4">
+        <HeroCarousel images={carouselImages.contents} />
+        <div className="flex gap-4">
+          <PostListCard
+            title="공지사항"
+            to={PATH.NOTICE}
+            posts={noticeList.contents}
+          />
+          <PostListCard
+            title="학부소식"
+            to={PATH.NEWS}
+            posts={newsList.contents}
+          />
+        </div>
+      </section>
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary

> #72 

어드민의 메인페이지를 추가하였어요.

## Tasks

- 어드민 메인페이지 추가
    - 커뮤니티와 유사하게 캐러셀 이미지, 공지사항/학부소식(5개까지만)으로 구성하였어요.


## To Reviewer

끝이 보여갑니다,,


## Screenshot

![image](https://github.com/user-attachments/assets/109b5ee3-0410-43ac-a6d8-3f878a019cac)
![image](https://github.com/user-attachments/assets/7983d772-2732-4544-892c-7a2993ca2ef4)

