### PR TITLE
fix(admin): tailwind가 tiptap에서 적용이 되지 않던 현상 해결

### DIFF
--- a/apps/admin/src/styles/globals.css
+++ b/apps/admin/src/styles/globals.css
@@ -1,5 +1,6 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable-dynamic-subset.css");
 @import "tailwindcss";
+@source '../../../../packages/tiptap/**/*.{ts,tsx}';
 
 :root {
   font-family:


### PR DESCRIPTION
## Summary

> #136 

tailwind css가 tiptap에서 적용되지 않던 현상을 해결했어요.

## Tasks

- global.css에서 tiptap 패키지 추가
    - tiptap 패키지에서 사용한 tailwind css의 클래스들이 빌드되지 않아, tiptap 패키지의 경로를 `@source`를 통해 명시해주었어요.



