### PR TITLE
feat(community): 마이페이지에서의 토큰 검증 로직 추가

### DIFF
--- a/apps/community/src/app/my/change-password/page.tsx
+++ b/apps/community/src/app/my/change-password/page.tsx
@@ -1,7 +1,9 @@
+export const dynamic = 'force-dynamic'
+
 import ChangePasswordForm from '~/features/change-password/components/change-password-form'
 import { PageHeader } from '~/shared/components/page-header/page-header'
 
-const ChangePasswordPage = () => {
+export default function ChangePasswordPage() {
   return (
     <>
       <PageHeader
@@ -12,5 +14,3 @@ const ChangePasswordPage = () => {
     </>
   )
 }
-
-export default ChangePasswordPage

--- a/apps/community/src/app/my/page.tsx
+++ b/apps/community/src/app/my/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { PageHeader } from '~/shared/components/page-header/page-header'
 import { MyInformation } from '~/widgets/profile/components/my-information'
 

--- a/apps/community/src/features/profile/services/remotes.ts
+++ b/apps/community/src/features/profile/services/remotes.ts
@@ -1,5 +1,6 @@
 import { END_POINT } from '~/shared/constants/api'
 import { http } from '~/shared/utils/http'
+import { isValidateToken } from '~/shared/utils/token'
 
 interface MyProfile {
   id: string
@@ -13,10 +14,16 @@ interface MyProfile {
 type MyProfileUpdate = Pick<MyProfile, 'phone' | 'email'>
 
 function getMyProfile() {
+  if (!isValidateToken()) {
+    throw new Error('Invalid token')
+  }
   return http.get<MyProfile>(END_POINT.MY_PROFILE)
 }
 
 function patchMyProfile(data: MyProfileUpdate) {
+  if (!isValidateToken()) {
+    throw new Error('Invalid token')
+  }
   return http.patch<MyProfileUpdate>(END_POINT.EDIT_MY_PROFILE, data)
 }
 

--- a/apps/community/src/shared/utils/token.ts
+++ b/apps/community/src/shared/utils/token.ts
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/navigation'
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '~/shared/constants/api'
 
 function getAccessToken(): string | null {
@@ -33,4 +34,26 @@ function getToken() {
   return [accessToken, refreshToken] as const
 }
 
-export { getAccessToken, getRefreshToken, removeTokens, getToken }
+function isValidateToken() {
+  const accessToken = getAccessToken()
+
+  if (!accessToken) {
+    return false
+  }
+
+  try {
+    const payload = JSON.parse(atob(accessToken.split('.')[1] ?? ''))
+    const exp = payload.exp * 1000
+    return Date.now() < exp
+  } catch (error) {
+    return false
+  }
+}
+
+export {
+  getAccessToken,
+  getRefreshToken,
+  removeTokens,
+  getToken,
+  isValidateToken,
+}

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [".next"]
+    "ignore": [".next", "apps/admin/src/apis"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

> #143

마이페이지에서 토큰 검증 로직을 추가하였어요 .

## Tasks

- 마이페이지의 remote에서의 토큰 검증 로직 추가


## To Reviewer

토큰 검증 로직은 middleware를 활용하고 싶었으나, 현재 토큰을 쿠키에 저장하지 않아 활용하지 못하고, 단순히 토큰의 존재 유무만 확인하고 에러를 던지는 방식으로 구현하였어요.
추가적으로, 마이페이지와 같은 토큰이 필요한 페이지에는 `dynamic = 'force-dynamic'`을 적용하였어요.

