### PR TITLE
feature(graduate): 개발 작업용 로그인 임시구현 및 인스턴스 설정

### DIFF
--- a/apps/graduate/package.json
+++ b/apps/graduate/package.json
@@ -27,6 +27,7 @@
     "motion": "^12.23.24",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.1",
     "react-quill-new": "^3.6.0",
     "xlsx": "^0.18.5",
     "zustand": "^5.0.8"

--- a/apps/graduate/src/pages/login/api/submitLogin.ts
+++ b/apps/graduate/src/pages/login/api/submitLogin.ts
@@ -2,9 +2,9 @@ import { useMutation } from '@tanstack/react-query';
 
 import { post } from '~/shared/api';
 import { END_POINT } from '~/shared/constants';
+import { setAccessToken, setRefreshToken } from '~/shared/utils';
 
 import type { LoginFormData, LoginResponse } from '../model/login';
-import { setAccessToken, setRefreshToken } from '~/shared/utils';
 
 export const submitLogin = async (data: LoginFormData) => {
   const response = await post<LoginResponse>({

--- a/apps/graduate/src/pages/login/api/submitLogin.ts
+++ b/apps/graduate/src/pages/login/api/submitLogin.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { post } from '~/shared/api';
+import { END_POINT } from '~/shared/constants';
+
+import type { LoginFormData } from '../model/login';
+
+export const submitLogin = async (data: LoginFormData) => {
+  const response = await post({
+    request: END_POINT.AUTH.LOGIN,
+    data,
+  });
+  return response.data;
+};
+
+export const useSubmitLogin = () => {
+  return useMutation({
+    mutationFn: submitLogin,
+    onSuccess: () => {
+      alert(
+        '로그인 성공. 토큰을 발급받았습니다. admin 또는 client 페이지로 이동해 작업하세요.',
+      );
+    },
+    onError: () => {
+      alert('로그인 실패. 아이디와 비밀번호를 확인하세요.');
+    },
+  });
+};

--- a/apps/graduate/src/pages/login/api/submitLogin.ts
+++ b/apps/graduate/src/pages/login/api/submitLogin.ts
@@ -3,10 +3,11 @@ import { useMutation } from '@tanstack/react-query';
 import { post } from '~/shared/api';
 import { END_POINT } from '~/shared/constants';
 
-import type { LoginFormData } from '../model/login';
+import type { LoginFormData, LoginResponse } from '../model/login';
+import { setAccessToken, setRefreshToken } from '~/shared/utils';
 
 export const submitLogin = async (data: LoginFormData) => {
-  const response = await post({
+  const response = await post<LoginResponse>({
     request: END_POINT.AUTH.LOGIN,
     data,
   });
@@ -16,7 +17,9 @@ export const submitLogin = async (data: LoginFormData) => {
 export const useSubmitLogin = () => {
   return useMutation({
     mutationFn: submitLogin,
-    onSuccess: () => {
+    onSuccess: response => {
+      setAccessToken(response.accessToken);
+      setRefreshToken(response.refreshToken);
       alert(
         '로그인 성공. 토큰을 발급받았습니다. admin 또는 client 페이지로 이동해 작업하세요.',
       );

--- a/apps/graduate/src/pages/login/api/submitSignup.ts
+++ b/apps/graduate/src/pages/login/api/submitSignup.ts
@@ -7,7 +7,7 @@ import type { SignupFormData } from '../model/signup';
 
 const submitSignup = async (data: SignupFormData) => {
   const response = await post({
-    request: END_POINT.AUTH.SIGNUP,
+    request: END_POINT.USER.SIGNUP,
     data,
   });
   return response.data;

--- a/apps/graduate/src/pages/login/api/submitSignup.ts
+++ b/apps/graduate/src/pages/login/api/submitSignup.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { post } from '~/shared/api';
+import { END_POINT } from '~/shared/constants';
+
+import type { SignupFormData } from '../model/signup';
+
+const submitSignup = async (data: SignupFormData) => {
+  const response = await post({
+    request: END_POINT.AUTH.SIGNUP,
+    data,
+  });
+  return response.data;
+};
+
+export const useSubmitSignup = () => {
+  return useMutation({
+    mutationFn: submitSignup,
+    onSuccess: () => {
+      alert('회원가입 성공. 로그인해 토큰을 발급받을 수 있습니다.');
+    },
+    onError: error => {
+      alert('회원가입 실패. ' + error.message);
+    },
+  });
+};

--- a/apps/graduate/src/pages/login/model/login.ts
+++ b/apps/graduate/src/pages/login/model/login.ts
@@ -1,0 +1,4 @@
+export type LoginFormData = {
+  userId: string;
+  password: string;
+};

--- a/apps/graduate/src/pages/login/model/login.ts
+++ b/apps/graduate/src/pages/login/model/login.ts
@@ -2,3 +2,8 @@ export type LoginFormData = {
   userId: string;
   password: string;
 };
+
+export type LoginResponse = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/apps/graduate/src/pages/login/model/signup.ts
+++ b/apps/graduate/src/pages/login/model/signup.ts
@@ -1,0 +1,8 @@
+import type { LoginFormData } from './login';
+
+export type SignupFormData = LoginFormData & {
+  name: string;
+  email: string;
+  phone: string;
+  major: string;
+};

--- a/apps/graduate/src/pages/login/styles/loginForm.css.ts
+++ b/apps/graduate/src/pages/login/styles/loginForm.css.ts
@@ -1,0 +1,56 @@
+import { style } from '@vanilla-extract/css';
+
+export const form = style({
+  width: '300px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});
+
+export const inputWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const input = style({
+  boxSizing: 'border-box',
+  padding: '8px',
+  borderRadius: '4px',
+  border: '1px solid #ccc',
+  width: '100%',
+  fontSize: '14px',
+
+  ':focus': {
+    outline: 'none',
+    borderColor: '#4A90E2',
+  },
+});
+
+export const errorMessage = style({
+  color: 'red',
+  fontSize: '12px',
+  margin: '4px 0 0 0',
+});
+
+export const submitButton = style({
+  width: '300px',
+  padding: '8px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  border: 'none',
+  backgroundColor: '#4A90E2',
+  color: 'white',
+  fontSize: '14px',
+  fontWeight: '500',
+  transition: 'all 0.2s ease-in-out',
+
+  ':hover': {
+    backgroundColor: '#357ABD',
+  },
+
+  ':disabled': {
+    cursor: 'not-allowed',
+    opacity: 0.6,
+    backgroundColor: '#4A90E2',
+  },
+});

--- a/apps/graduate/src/pages/login/ui/LoginForm.tsx
+++ b/apps/graduate/src/pages/login/ui/LoginForm.tsx
@@ -1,0 +1,61 @@
+import { useForm } from 'react-hook-form';
+
+import { Button } from '~/shared/components';
+
+import { useSubmitLogin } from '../api/submitLogin';
+import type { LoginFormData } from '../model/login';
+import * as styles from '../styles/loginForm.css';
+
+export default function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormData>({
+    defaultValues: {
+      userId: '',
+      password: '',
+    },
+  });
+
+  const { mutate: submitLogin, isPending } = useSubmitLogin();
+
+  const onSubmit = (data: LoginFormData) => {
+    console.log('로그인 데이터:', data);
+    submitLogin(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <div className={styles.inputWrapper}>
+        <input
+          type='text'
+          placeholder='학번'
+          {...register('userId', {
+            required: '학번을 입력하세요',
+          })}
+          className={styles.input}
+        />
+        {errors.userId && (
+          <p className={styles.errorMessage}>{errors.userId.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='password'
+          placeholder='비밀번호'
+          {...register('password', {
+            required: '비밀번호를 입력하세요',
+          })}
+          className={styles.input}
+        />
+        {errors.password && (
+          <p className={styles.errorMessage}>{errors.password.message}</p>
+        )}
+      </div>
+      <Button size='md' type='submit' disabled={isPending}>
+        {isPending ? '로그인 중...' : '로그인'}
+      </Button>
+    </form>
+  );
+}

--- a/apps/graduate/src/pages/login/ui/LoginPage.tsx
+++ b/apps/graduate/src/pages/login/ui/LoginPage.tsx
@@ -3,6 +3,11 @@ import { useRouter } from '@tanstack/react-router';
 import { Button } from '~/shared/components';
 import { ROUTE } from '~/shared/constants';
 
+import LoginForm from './LoginForm';
+import SignupForm from './SignupForm';
+
+import { vars } from '~/vars.css';
+
 export default function LoginPage() {
   const router = useRouter();
   const { setIsAuthenticated, setIsAdmin } = router.options.context.auth;
@@ -11,15 +16,22 @@ export default function LoginPage() {
     <div
       style={{
         color: 'white',
-        display: 'grid',
-        placeItems: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
         height: '100vh',
+        gap: vars.spacing.lg,
+        width: '100%',
       }}
     >
-      <div style={{ display: 'flex', gap: '10px' }}>
+      <LoginForm />
+      <SignupForm />
+      <div style={{ display: 'flex', gap: vars.spacing.sm, width: '300px' }}>
         <Button
-          size='lg'
+          size='md'
           type='button'
+          style={{ flex: 1, textWrap: 'nowrap' }}
           onClick={() => {
             Promise.all([setIsAuthenticated(true), setIsAdmin(false)]).then(
               () => {
@@ -31,8 +43,9 @@ export default function LoginPage() {
           Client 클라이언트
         </Button>
         <Button
-          size='lg'
+          size='md'
           type='button'
+          style={{ flex: 1, textWrap: 'nowrap' }}
           onClick={() => {
             Promise.all([setIsAuthenticated(true), setIsAdmin(true)]).then(
               () => {

--- a/apps/graduate/src/pages/login/ui/SignupForm.tsx
+++ b/apps/graduate/src/pages/login/ui/SignupForm.tsx
@@ -18,7 +18,7 @@ export default function SignupForm() {
       name: '',
       email: '',
       phone: '',
-      major: '',
+      major: 'CS',
     },
   });
 
@@ -47,13 +47,9 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='password'
-          placeholder='비밀번호 (예: password1234!)'
+          placeholder='비밀번호'
           {...register('password', {
             required: '비밀번호를 입력하세요',
-            minLength: {
-              value: 8,
-              message: '비밀번호는 최소 8자 이상이어야 합니다',
-            },
           })}
           className={styles.input}
         />
@@ -64,7 +60,7 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='text'
-          placeholder='이름 (예: 박민준)'
+          placeholder='이름'
           {...register('name', {
             required: '이름을 입력하세요',
           })}
@@ -77,7 +73,7 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='email'
-          placeholder='이메일 (예: example@kyonggi.ac.kr)'
+          placeholder='이메일'
           {...register('email', {
             required: '이메일을 입력하세요',
             pattern: {
@@ -94,7 +90,7 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='tel'
-          placeholder='전화번호 (예: 010-1234-5678)'
+          placeholder='전화번호 (010-1234-5678)'
           {...register('phone', {
             required: '전화번호를 입력하세요',
             pattern: {
@@ -111,7 +107,7 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='text'
-          placeholder='전공 (예: CSE)'
+          placeholder='전공 (예: CS)'
           {...register('major', {
             required: '전공을 입력하세요',
           })}

--- a/apps/graduate/src/pages/login/ui/SignupForm.tsx
+++ b/apps/graduate/src/pages/login/ui/SignupForm.tsx
@@ -1,0 +1,129 @@
+import { useForm } from 'react-hook-form';
+
+import { Button } from '~/shared/components';
+
+import { useSubmitSignup } from '../api/submitSignup';
+import type { SignupFormData } from '../model/signup';
+import * as styles from '../styles/loginForm.css';
+
+export default function SignupForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignupFormData>({
+    defaultValues: {
+      userId: '',
+      password: '',
+      name: '',
+      email: '',
+      phone: '',
+      major: '',
+    },
+  });
+
+  const { mutate: submitSignup, isPending } = useSubmitSignup();
+
+  const onSubmit = (data: SignupFormData) => {
+    console.log('회원가입 데이터:', data);
+    submitSignup(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <div className={styles.inputWrapper}>
+        <input
+          type='text'
+          placeholder='학번 (예: 202412345)'
+          {...register('userId', {
+            required: '학번을 입력하세요',
+          })}
+          className={styles.input}
+        />
+        {errors.userId && (
+          <p className={styles.errorMessage}>{errors.userId.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='password'
+          placeholder='비밀번호 (예: password1234!)'
+          {...register('password', {
+            required: '비밀번호를 입력하세요',
+            minLength: {
+              value: 8,
+              message: '비밀번호는 최소 8자 이상이어야 합니다',
+            },
+          })}
+          className={styles.input}
+        />
+        {errors.password && (
+          <p className={styles.errorMessage}>{errors.password.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='text'
+          placeholder='이름 (예: 박민준)'
+          {...register('name', {
+            required: '이름을 입력하세요',
+          })}
+          className={styles.input}
+        />
+        {errors.name && (
+          <p className={styles.errorMessage}>{errors.name.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='email'
+          placeholder='이메일 (예: example@kyonggi.ac.kr)'
+          {...register('email', {
+            required: '이메일을 입력하세요',
+            pattern: {
+              value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+              message: '올바른 이메일 형식이 아닙니다',
+            },
+          })}
+          className={styles.input}
+        />
+        {errors.email && (
+          <p className={styles.errorMessage}>{errors.email.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='tel'
+          placeholder='전화번호 (예: 010-1234-5678)'
+          {...register('phone', {
+            required: '전화번호를 입력하세요',
+            pattern: {
+              value: /^01[0-9]-\d{4}-\d{4}$/,
+              message: '올바른 전화번호 형식이 아닙니다 (예: 010-1234-5678)',
+            },
+          })}
+          className={styles.input}
+        />
+        {errors.phone && (
+          <p className={styles.errorMessage}>{errors.phone.message}</p>
+        )}
+      </div>
+      <div className={styles.inputWrapper}>
+        <input
+          type='text'
+          placeholder='전공 (예: CSE)'
+          {...register('major', {
+            required: '전공을 입력하세요',
+          })}
+          className={styles.input}
+        />
+        {errors.major && (
+          <p className={styles.errorMessage}>{errors.major.message}</p>
+        )}
+      </div>
+      <Button size='md' type='submit' disabled={isPending}>
+        {isPending ? '회원가입 중...' : '회원가입'}
+      </Button>
+    </form>
+  );
+}

--- a/apps/graduate/src/pages/login/ui/SignupForm.tsx
+++ b/apps/graduate/src/pages/login/ui/SignupForm.tsx
@@ -18,7 +18,7 @@ export default function SignupForm() {
       name: '',
       email: '',
       phone: '',
-      major: 'CS',
+      major: 'CSE',
     },
   });
 
@@ -107,7 +107,7 @@ export default function SignupForm() {
       <div className={styles.inputWrapper}>
         <input
           type='text'
-          placeholder='전공 (예: CS)'
+          placeholder='전공 (예: CSE)'
           {...register('major', {
             required: '전공을 입력하세요',
           })}

--- a/apps/graduate/src/shared/api/axios.ts
+++ b/apps/graduate/src/shared/api/axios.ts
@@ -58,7 +58,7 @@ async function refreshAccessToken(): Promise<string> {
       }
 
       const response = await refreshInstance.post<RefreshTokenResponse>(
-        END_POINT.AUTH_REFRESH,
+        END_POINT.AUTH.REFRESH,
         { refreshToken },
       );
 

--- a/apps/graduate/src/shared/api/axios.ts
+++ b/apps/graduate/src/shared/api/axios.ts
@@ -1,9 +1,16 @@
 import axios, {
+  AxiosInstance,
   type AxiosResponse,
   type InternalAxiosRequestConfig,
 } from 'axios';
 
-import { END_POINT, ENV_API_URL } from '~/shared/constants';
+import {
+  API_AUTH_URL,
+  API_ADMIN_URL,
+  END_POINT,
+  API_URL,
+  type EndpointPath,
+} from '~/shared/constants';
 import { parseError, logout } from '~/shared/utils';
 import {
   getAccessToken,
@@ -13,7 +20,7 @@ import {
 } from '~/shared/utils';
 
 interface BaseRequestConfig {
-  request: string;
+  request: EndpointPath;
   headers?: Record<string, string>;
 }
 
@@ -34,12 +41,33 @@ interface RefreshTokenResponse {
   refreshToken?: string;
 }
 
-const instance = axios.create({
-  baseURL: ENV_API_URL,
+/**
+ * https://aics-api.ummdev.com/
+ * 에 전송하는 사용자 API baseURL이 적용된 Instance입니다 */
+const userInstance = axios.create({
+  baseURL: API_URL,
 });
 
+/**
+ * https://aics-admin.ummdev.com/
+ * 에 전송하는 관리자 API baseURL이 적용된 Instance입니다 */
+const adminInstance = axios.create({
+  baseURL: API_ADMIN_URL,
+});
+
+/**
+ * https://aics-auth.ummdev.com/
+ * 에 전송하는 인증 API baseURL이 적용된 Instance입니다 */
+const authInstance = axios.create({
+  baseURL: API_AUTH_URL,
+});
+
+/**
+ * 토큰 갱신용 Instance입니다.
+ * reissue 엔드포인트가 속한 auth baseUrl이 적용되었습니다
+ */
 const refreshInstance = axios.create({
-  baseURL: ENV_API_URL,
+  baseURL: API_AUTH_URL,
 });
 
 let refreshTokenPromise: Promise<string> | null = null;
@@ -86,7 +114,61 @@ function handleAxiosError(error: unknown): never {
   throw new Error(errorInfo.message);
 }
 
-instance.interceptors.request.use(
+function setupRequestInterceptor(instance: AxiosInstance) {
+  instance.interceptors.request.use(
+    config => {
+      const token = getAccessToken();
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    },
+    error => {
+      return Promise.reject(error);
+    },
+  );
+}
+
+function setupResponseInterceptor(
+  instance: AxiosInstance,
+  retryInstance: AxiosInstance,
+) {
+  instance.interceptors.response.use(
+    response => response,
+    async error => {
+      const originalRequest = error.config as
+        | CustomAxiosRequestConfig
+        | undefined;
+
+      if (!originalRequest) {
+        return Promise.reject(error);
+      }
+
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        try {
+          const newAccessToken = await refreshAccessToken();
+
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return retryInstance(originalRequest);
+        } catch (refreshError) {
+          return Promise.reject(refreshError);
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}
+
+setupRequestInterceptor(userInstance);
+setupResponseInterceptor(userInstance, refreshInstance);
+
+setupRequestInterceptor(adminInstance);
+setupResponseInterceptor(adminInstance, refreshInstance);
+
+authInstance.interceptors.request.use(
   config => {
     const token = getAccessToken();
     if (token) {
@@ -99,37 +181,116 @@ instance.interceptors.request.use(
   },
 );
 
-instance.interceptors.response.use(
-  response => response,
-  async error => {
-    const originalRequest = error.config as
-      | CustomAxiosRequestConfig
-      | undefined;
-
-    if (!originalRequest) {
-      return Promise.reject(error);
+function getAllEndpointPaths(
+  obj: (typeof END_POINT)[keyof typeof END_POINT],
+): EndpointPath[] {
+  const paths: EndpointPath[] = [];
+  for (const key in obj) {
+    const value = obj[key as keyof typeof obj];
+    if (typeof value === 'string') {
+      paths.push(value as EndpointPath);
     }
+  }
+  return paths;
+}
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
+function selectInstanceByRequest(request: EndpointPath): AxiosInstance {
+  const authPaths = getAllEndpointPaths(END_POINT.AUTH);
+  if (authPaths.some(path => request === path || request.startsWith(path))) {
+    return authInstance;
+  }
 
+  const adminPaths = getAllEndpointPaths(END_POINT.ADMIN);
+  if (
+    adminPaths.length > 0 &&
+    adminPaths.some(path => request === path || request.startsWith(path))
+  ) {
+    return adminInstance;
+  }
+
+  return userInstance;
+}
+
+function createHttpMethods(instance: AxiosInstance) {
+  return {
+    async get<TResponse = unknown, TParams = unknown>(
+      config: GetRequestConfig<TParams>,
+    ): Promise<AxiosResponse<TResponse>> {
+      const { request, headers, params } = config;
       try {
-        const newAccessToken = await refreshAccessToken();
-
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-        return instance(originalRequest);
-      } catch (refreshError) {
-        return Promise.reject(refreshError);
+        const response = await instance.get<TResponse>(request, {
+          params,
+          headers,
+        });
+        return response;
+      } catch (error: unknown) {
+        handleAxiosError(error);
       }
-    }
+    },
 
-    return Promise.reject(error);
-  },
-);
+    async post<TResponse = unknown, TData = unknown>(
+      config: MutationRequestConfig<TData>,
+    ): Promise<AxiosResponse<TResponse>> {
+      const { request, data, headers } = config;
+      try {
+        const response = await instance.post<
+          TResponse,
+          AxiosResponse<TResponse>,
+          TData
+        >(request, data, {
+          headers,
+        });
+        return response;
+      } catch (error: unknown) {
+        handleAxiosError(error);
+      }
+    },
 
-export async function get<TResponse = unknown, TParams = unknown>(
+    async put<TResponse = unknown, TData = unknown>(
+      config: MutationRequestConfig<TData>,
+    ): Promise<AxiosResponse<TResponse>> {
+      const { request, data, headers } = config;
+      try {
+        const response = await instance.put<
+          TResponse,
+          AxiosResponse<TResponse>,
+          TData
+        >(request, data, {
+          headers,
+        });
+        return response;
+      } catch (error: unknown) {
+        handleAxiosError(error);
+      }
+    },
+
+    async del<TResponse = unknown>(
+      config: BaseRequestConfig,
+    ): Promise<AxiosResponse<TResponse>> {
+      const { request, headers } = config;
+      try {
+        const response = await instance.delete<
+          TResponse,
+          AxiosResponse<TResponse>
+        >(request, {
+          headers,
+        });
+        return response;
+      } catch (error: unknown) {
+        handleAxiosError(error);
+      }
+    },
+  };
+}
+
+export const userApi = createHttpMethods(userInstance);
+export const adminApi = createHttpMethods(adminInstance);
+export const authApi = createHttpMethods(authInstance);
+
+async function get<TResponse = unknown, TParams = unknown>(
   config: GetRequestConfig<TParams>,
 ): Promise<AxiosResponse<TResponse>> {
+  const instance = selectInstanceByRequest(config.request);
   const { request, headers, params } = config;
   try {
     const response = await instance.get<TResponse>(request, {
@@ -142,9 +303,10 @@ export async function get<TResponse = unknown, TParams = unknown>(
   }
 }
 
-export async function post<TResponse = unknown, TData = unknown>(
+async function post<TResponse = unknown, TData = unknown>(
   config: MutationRequestConfig<TData>,
 ): Promise<AxiosResponse<TResponse>> {
+  const instance = selectInstanceByRequest(config.request);
   const { request, data, headers } = config;
   try {
     const response = await instance.post<
@@ -160,9 +322,10 @@ export async function post<TResponse = unknown, TData = unknown>(
   }
 }
 
-export async function put<TResponse = unknown, TData = unknown>(
+async function put<TResponse = unknown, TData = unknown>(
   config: MutationRequestConfig<TData>,
 ): Promise<AxiosResponse<TResponse>> {
+  const instance = selectInstanceByRequest(config.request);
   const { request, data, headers } = config;
   try {
     const response = await instance.put<
@@ -178,9 +341,10 @@ export async function put<TResponse = unknown, TData = unknown>(
   }
 }
 
-export async function del<TResponse = unknown>(
+async function del<TResponse = unknown>(
   config: BaseRequestConfig,
 ): Promise<AxiosResponse<TResponse>> {
+  const instance = selectInstanceByRequest(config.request);
   const { request, headers } = config;
   try {
     const response = await instance.delete<TResponse, AxiosResponse<TResponse>>(
@@ -194,3 +358,5 @@ export async function del<TResponse = unknown>(
     handleAxiosError(error);
   }
 }
+
+export { get, post, put, del };

--- a/apps/graduate/src/shared/constants/endpoint.ts
+++ b/apps/graduate/src/shared/constants/endpoint.ts
@@ -1,5 +1,10 @@
-export const ENV_API_URL = import.meta.env.VITE_API_URL;
+export const ENV_API_URL =
+  import.meta.env.VITE_API_URL || 'https://aics-api.ummdev.com/';
 
 export const END_POINT = {
-  AUTH_REFRESH: '/auth/refresh', // 명세서 업데이트가 안돼서 확인 필요해요.
+  AUTH: {
+    LOGIN: '/api/v1/auth/login',
+    SIGNUP: '/api/v1/users/signup',
+    REFRESH: '/api/v1/auth/reissue',
+  },
 } as const;

--- a/apps/graduate/src/shared/constants/endpoint.ts
+++ b/apps/graduate/src/shared/constants/endpoint.ts
@@ -9,7 +9,7 @@ export const API_ADMIN_URL =
 
 export type EndpointValue<T> = T extends string
   ? T
-  : T extends Record<string, any>
+  : T extends Record<string, unknown>
     ? {
         [K in keyof T]: EndpointValue<T[K]>;
       }[keyof T]

--- a/apps/graduate/src/shared/constants/endpoint.ts
+++ b/apps/graduate/src/shared/constants/endpoint.ts
@@ -1,10 +1,35 @@
-export const ENV_API_URL =
-  import.meta.env.VITE_API_URL || 'https://aics-api.ummdev.com/';
+export const API_URL =
+  import.meta.env.VITE_API_URL || 'https://aics-api.ummdev.com';
 
+export const API_AUTH_URL =
+  import.meta.env.VITE_AUTH_API_URL || 'https://aics-auth.ummdev.com';
+
+export const API_ADMIN_URL =
+  import.meta.env.VITE_ADMIN_API_URL || 'https://aics-admin.ummdev.com';
+
+export type EndpointValue<T> = T extends string
+  ? T
+  : T extends Record<string, any>
+    ? {
+        [K in keyof T]: EndpointValue<T[K]>;
+      }[keyof T]
+    : never;
+
+export type EndpointPath = EndpointValue<typeof END_POINT>;
+
+/**
+ * AUTH, ADMIN, USER 세 가지 타입의 엔드포인트를 정의합니다.
+ * 이떄 타입의 구분은 인스턴스(baseURL)에 따라 결정됩니다.
+ * 타입 아래 더한 Depth를 가지는 것은 불가능합니다. (ex. AUTH.LOGIN.DETAIL.USER_ID)
+ * 현재 Depth 지켜서 엔드포인트 추가해주세요.
+ */
 export const END_POINT = {
   AUTH: {
     LOGIN: '/api/v1/auth/login',
-    SIGNUP: '/api/v1/users/signup',
     REFRESH: '/api/v1/auth/reissue',
+  },
+  ADMIN: {},
+  USER: {
+    SIGNUP: '/api/v1/users/signup',
   },
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.56.1
+        version: 7.56.1(react@19.1.0)
       react-quill-new:
         specifier: ^3.6.0
         version: 3.6.0(quill-delta@5.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12497,6 +12500,10 @@ snapshots:
   react-hook-form@7.56.1(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-hook-form@7.56.1(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
## Summary

> related #200

개발 작업용 로그인 기능 임시 구현했습니다.

## Tasks

- 분리된 3가지 BaseUrl에 따른 인스턴스 정의
- 분리된 3가지 인스턴스에 대한 엔드포인트 상수 정의, 엔드포인트 상수 키에 따른 인스턴스 자동 적용
- 엔드포인트 상수 타입 안정성 강화 axios 인스턴스

## To Reviewer

```javascript
/**
 * AUTH, ADMIN, USER 세 가지 타입의 엔드포인트를 정의합니다.
 * 이떄 타입의 구분은 인스턴스(baseURL)에 따라 결정됩니다.
 * 타입 아래 더한 Depth를 가지는 것은 불가능합니다. (ex. AUTH.LOGIN.DETAIL.USER_ID)
 * 현재 Depth 지켜서 엔드포인트 추가해주세요.
 */
export const END_POINT = {
  AUTH: {
    LOGIN: '/api/v1/auth/login',
    REFRESH: '/api/v1/auth/reissue',
  },
  ADMIN: {},
  USER: {
    SIGNUP: '/api/v1/users/signup',
  },
} as const;
```

- Auth, Admin, User 세 가지 baseUrl 존재함에 따라 인스턴스를 분리했고, `END_POINT` 상수에서 해당하는 baseUrl에 매칭되는 키 아래에 경로 정의하면 알아서 알맞는 instance 에 요청 보낼 수 있도록 설정해뒀습니다.
- 해당 내용 확인하시고 API 연동하실 때 알맞게 상수에 경로 추가해주시면 됩니다