### PR TITLE
feature(graduate): 승인 취소 토글 추가 및 상세보기 연락처 추가

### DIFF
--- a/apps/graduate/src/admin/features/studentDetail/types/studentDetail.ts
+++ b/apps/graduate/src/admin/features/studentDetail/types/studentDetail.ts
@@ -8,5 +8,6 @@ export interface StudentDetailApiResponse {
   advisor: string;
   major: string;
   capstoneCompletion: boolean;
+  phone: string;
   status: SubmissionStatus;
 }

--- a/apps/graduate/src/admin/pages/filePreview/ui/FilePreviewPage.tsx
+++ b/apps/graduate/src/admin/pages/filePreview/ui/FilePreviewPage.tsx
@@ -13,11 +13,16 @@ import { getSubmissionTypeIndex } from '../../schedule/constants';
 import { useFile } from '../model';
 import * as style from '../styles/FilePreviewPage.css';
 
-import { useGraduationBatchApproval } from '~/admin/entities/graduation-approval/model';
+import {
+  useGraduationBatchApproval,
+  useGraduationBatchDisapproval,
+} from '~/admin/entities/graduation-approval/model';
 import { useStudentDetail } from '~/admin/features/studentDetail';
 import {
   APPROVE_FAILED,
   APPROVE_SUCCESS,
+  DISAPPROVE_FAILED,
+  DISAPPROVE_SUCCESS,
 } from '~/admin/shared/constants/actionTexts';
 
 export default function FilePreviewPage() {
@@ -51,6 +56,23 @@ export default function FilePreviewPage() {
         await refetch();
       },
     });
+
+  const { disapproveGraduationUsers, mutation: disapprovalMutation } =
+    useGraduationBatchDisapproval({
+      onSuccess: async () => {
+        toast.success(DISAPPROVE_SUCCESS);
+        await refetch();
+      },
+    });
+
+  const handleCancelApprove = async () => {
+    const result = await disapproveGraduationUsers([
+      { graduationUserId, submissionId: fileId },
+    ]);
+    if (result.successCount === 0) {
+      toast.error(DISAPPROVE_FAILED);
+    }
+  };
 
   const clearHideTimeout = () => {
     if (hideTimeoutRef.current !== null) {
@@ -180,9 +202,11 @@ export default function FilePreviewPage() {
                 name={name}
                 isApproved={approval ?? false}
                 onApprove={handleApprove}
+                onCancelApprove={handleCancelApprove}
                 onChangeFile={handleNextFile}
                 canNavigate={canNavigate}
                 isApproving={approvalMutation.isPending}
+                isCancellingApprove={disapprovalMutation.isPending}
               />
             </div>
           </div>

--- a/apps/graduate/src/admin/pages/filePreview/ui/FilePreviewToolbar.tsx
+++ b/apps/graduate/src/admin/pages/filePreview/ui/FilePreviewToolbar.tsx
@@ -7,9 +7,11 @@ interface FilePreviewToolbarProps {
   name: string;
   isApproved: boolean;
   onApprove: () => void;
+  onCancelApprove: () => void;
   onChangeFile: () => void;
   canNavigate: boolean;
   isApproving: boolean;
+  isCancellingApprove: boolean;
 }
 
 export default function FilePreviewToolbar({
@@ -17,23 +19,38 @@ export default function FilePreviewToolbar({
   name,
   isApproved,
   onApprove,
+  onCancelApprove,
   onChangeFile,
   canNavigate,
   isApproving,
+  isCancellingApprove,
 }: FilePreviewToolbarProps) {
   return (
     <div className={style.toolbar}>
       <span className={style.infoItem}>학번: {studentId}</span>
       <span className={style.infoItem}>이름: {name}</span>
-      <Button
-        type='primary'
-        onClick={onApprove}
-        disabled={isApproved || isApproving}
-        loading={isApproving}
-        className={style.button}
-      >
-        {isApproved ? '승인됨' : '승인'}
-      </Button>
+      {isApproved ? (
+        <Button
+          type='primary'
+          danger
+          onClick={onCancelApprove}
+          disabled={isCancellingApprove}
+          loading={isCancellingApprove}
+          className={style.button}
+        >
+          승인 취소
+        </Button>
+      ) : (
+        <Button
+          type='primary'
+          onClick={onApprove}
+          disabled={isApproving}
+          loading={isApproving}
+          className={style.button}
+        >
+          승인
+        </Button>
+      )}
       <Button
         onClick={onChangeFile}
         disabled={!canNavigate}

--- a/apps/graduate/src/admin/shared/ui/UserDetailModal/UserDetailModal.tsx
+++ b/apps/graduate/src/admin/shared/ui/UserDetailModal/UserDetailModal.tsx
@@ -39,6 +39,7 @@ export default function UserDetailModal({
     advisor,
     major,
     capstoneCompletion,
+    phone,
     status,
   } = studentDetail ?? {};
 
@@ -133,9 +134,10 @@ export default function UserDetailModal({
             <Descriptions.Item label='기타자격'>
               {capstoneCompletion ? '캡스톤 이수' : '캡스톤 미이수'}
             </Descriptions.Item>
-            <Descriptions.Item label='상태' span={2}>
+            <Descriptions.Item label='상태'>
               {getStatusLabel(status)}
             </Descriptions.Item>
+            <Descriptions.Item label='연락처'>{phone}</Descriptions.Item>
           </Descriptions>
         </Container>
 

--- a/apps/graduate/src/admin/widgets/StudentAddModal/model/constants.ts
+++ b/apps/graduate/src/admin/widgets/StudentAddModal/model/constants.ts
@@ -5,6 +5,7 @@ export const HEADER_NAMES = {
   capstoneCompletion: '캡스톤 이수 여부',
   graduationDate: '졸업 예정',
   department: '학과',
+  phone: '연락처',
 } as const;
 
 export const MODE_OPTIONS = [
@@ -52,6 +53,11 @@ export const SINGLE_FIELD_TEXT = {
     label: '학과',
     placeholder: '학과를 입력해주세요',
     required: '학과를 입력해주세요',
+  },
+  phone: {
+    label: '연락처',
+    placeholder: '연락처를 입력해주세요',
+    required: '연락처를 입력해주세요',
   },
   submitLabel: '입력',
 };

--- a/apps/graduate/src/admin/widgets/StudentAddModal/model/parsers.ts
+++ b/apps/graduate/src/admin/widgets/StudentAddModal/model/parsers.ts
@@ -38,6 +38,7 @@ const getHeaderIndices = (header: string[]) => {
       capstone: idx(HEADER_NAMES.capstoneCompletion, 3),
       grad: idx(HEADER_NAMES.graduationDate, 4),
       dept: idx(HEADER_NAMES.department, 5),
+      phone: idx(HEADER_NAMES.phone, 6),
     },
   };
 };
@@ -69,6 +70,7 @@ export function parseCsv(
       capstoneText: (cols[indices.capstone] || '').trim().toLowerCase(),
       grad: (cols[indices.grad] || '').trim(),
       dept: (cols[indices.dept] || '').trim(),
+      phone: (cols[indices.phone] || '').trim(),
       professorNameToId,
       seenStudentIds,
     });
@@ -121,6 +123,7 @@ export async function parseXlsx(
         capstoneText: getCell(indices.capstone).toLowerCase(),
         grad: getCell(indices.grad),
         dept: getCell(indices.dept),
+        phone: getCell(indices.phone),
         professorNameToId,
         seenStudentIds,
       });

--- a/apps/graduate/src/admin/widgets/StudentAddModal/model/validator.ts
+++ b/apps/graduate/src/admin/widgets/StudentAddModal/model/validator.ts
@@ -12,6 +12,7 @@ type ValidateOptions = {
   capstoneText: string;
   grad: string;
   dept: string;
+  phone: string;
   professorNameToId: ProfessorNameToId;
   seenStudentIds: Set<string>;
 };
@@ -37,6 +38,7 @@ export const validateStudentRow = ({
   capstoneText,
   grad,
   dept,
+  phone,
   professorNameToId,
   seenStudentIds,
 }: ValidateOptions): ValidateResult => {
@@ -47,6 +49,7 @@ export const validateStudentRow = ({
   if (!capstoneText) missing.push('capstoneCompletion');
   if (!grad) missing.push('graduationDate');
   if (!dept) missing.push('department');
+  if (!phone) missing.push('phone');
 
   if (missing.length > 0) {
     return {
@@ -137,6 +140,7 @@ export const validateStudentRow = ({
       capstoneCompletion,
       department: dept,
       graduationDate,
+      phone,
     },
   };
 };

--- a/apps/graduate/src/admin/widgets/StudentAddModal/ui/StudentAddMultiple.tsx
+++ b/apps/graduate/src/admin/widgets/StudentAddModal/ui/StudentAddMultiple.tsx
@@ -40,6 +40,7 @@ export default function StudentAddMultiple({
       capstoneCompletion: row.capstoneCompletion,
       department: row.department,
       graduationDate: row.graduationDate,
+      phone: row.phone,
     }));
 
   const handleSelectSubmit: ButtonProps['onClick'] = async () => {

--- a/apps/graduate/src/admin/widgets/StudentAddModal/ui/StudentAddSingle.tsx
+++ b/apps/graduate/src/admin/widgets/StudentAddModal/ui/StudentAddSingle.tsx
@@ -13,7 +13,7 @@ import {
 } from '../types/studentAddModal';
 
 type TextFieldConfig = {
-  name: 'studentId' | 'name' | 'department';
+  name: 'studentId' | 'name' | 'department' | 'phone';
   rules: FormItemProps['rules'];
   placeholder: string;
   label: string;
@@ -41,6 +41,12 @@ const TEXT_FIELD_CONFIGS: TextFieldConfig[] = [
     placeholder: SINGLE_FIELD_TEXT.department.placeholder,
     label: SINGLE_FIELD_TEXT.department.label,
   },
+  {
+    name: 'phone',
+    rules: [{ required: true, message: SINGLE_FIELD_TEXT.phone.required }],
+    placeholder: SINGLE_FIELD_TEXT.phone.placeholder,
+    label: SINGLE_FIELD_TEXT.phone.label,
+  },
 ];
 
 type FormValues = Omit<
@@ -49,6 +55,7 @@ type FormValues = Omit<
 > & {
   capstoneCompletion: CapstoneCompletionOption['value'];
   graduationDate: Dayjs | null;
+  phone: string;
 };
 
 export default function StudentAddSingle({
@@ -73,6 +80,7 @@ export default function StudentAddSingle({
       capstoneCompletion: v.capstoneCompletion === 'true',
       department: v.department.trim(),
       graduationDate: v.graduationDate.format('YYYY-MM'),
+      phone: v.phone.trim(),
     };
     onSubmit?.(payload);
     form.resetFields();

--- a/apps/graduate/src/shared/types/graduationUser.ts
+++ b/apps/graduate/src/shared/types/graduationUser.ts
@@ -5,4 +5,5 @@ export type GraduationUserCreateRequest = {
   capstoneCompletion: boolean;
   department: string;
   graduationDate: string;
+  phone: string;
 };


### PR DESCRIPTION
## Summary

>  close #234

## Tasks

- [ ] 승인 취소 토글 추가
- [ ] 연락처 추가
- [ ] 학생 추가에 연락처 추가

## To Reviewer

현재 중간보고서 미리보기로 접근 후 승인 취소를 하면, 최종 보고서는 승인인데, 중간 보고서는 승인 취소되는 형태로 구현되어 있습니다. 

전체 테이블에서 선택 후 취소하면, 최종보고서 > 중간보고서 순으로 두 번 눌러야 취소가 되던데, 중간보고서만 승인 취소할 경우가 있을꺼 같아, 따로 예외 처리는 안했습니다. 관련해서 의견 남겨주세요.

## Screenshot

<img width="628" height="587" alt="image" src="https://github.com/user-attachments/assets/85985537-1bb6-488d-a6ad-91762983c7f7" />
<img width="388" height="150" alt="image" src="https://github.com/user-attachments/assets/b85a352a-67f0-4740-8b52-290dd1183614" />
<img width="357" height="152" alt="image" src="https://github.com/user-attachments/assets/87bc92e3-fa13-410a-82b0-bde4a4508630" />
<img width="597" height="822" alt="image" src="https://github.com/user-attachments/assets/74a82bf2-b4dc-4284-b841-f9449635e144" />
